### PR TITLE
Add missing jar

### DIFF
--- a/pmmlserver/rockcraft.yaml
+++ b/pmmlserver/rockcraft.yaml
@@ -2,7 +2,7 @@
 name: pmml-server
 summary: Pmml server for Kserve deployments
 description: "Kserve Pmml server"
-version: "v0.11.0_22.04_1"
+version: "v0.11.0-22.04-1"
 license: Apache-2.0
 base: ubuntu:22.04
 build-base: ubuntu:22.04

--- a/pmmlserver/rockcraft.yaml
+++ b/pmmlserver/rockcraft.yaml
@@ -49,7 +49,9 @@ parts:
       cp -fr python/kserve $CRAFT_PART_INSTALL/kserve
 
       mkdir -p $CRAFT_PART_INSTALL/usr/local/lib/python3.10/dist-packages
+      mkdir -p $CRAFT_PART_INSTALL/usr/local/share
       cp -fr /usr/local/lib/python3.10/dist-packages/* $CRAFT_PART_INSTALL/usr/local/lib/python3.10/dist-packages/
+      cp -fr /usr/local/share/* $CRAFT_PART_INSTALL/usr/local/share/
   
   third-party:
     plugin: nil


### PR DESCRIPTION
Add missing JAR to ROCK (it stays in /local/share during build). The jar is needed in order to deploy pmmlserver workload with kserve. 

Steps to test: 
- Build the ROCK 
- Change the [default image](https://github.com/canonical/kserve-operators/blob/main/charms/kserve-controller/src/default-custom-images.json#L12) in kserve-controller
- Deploy kserve-controller with adjusted image
- Run Pmmlserver [workload](https://github.com/canonical/kserve-operators/blob/main/charms/kserve-controller/tests/integration/pmml-server.yaml).