### PR TITLE
feat: add kserve storage initializer rock

### DIFF
--- a/storage-initializer/rockcraft.yaml
+++ b/storage-initializer/rockcraft.yaml
@@ -2,7 +2,7 @@
 name: storage-initializer
 summary: Storage initializer for Kserve deployments
 description: "Kserve storage initializer"
-version: "v0.10.0-22.04-1"
+version: "0.10.0"
 license: Apache-2.0
 base: ubuntu@22.04
 platforms:


### PR DESCRIPTION
Adds a rockcraft.yaml for kserve storage-initializer
Closes #11 

## Testing:
### Build the ROCK and import it to microk8s
``` 
rockcraft clean && rockcraft pack -v
 sudo skopeo --insecure-policy copy oci-archive:storage-initializer_v0.10.0-22.04-1_amd64.rock docker-daemon:storage-initializer_v0.10.0-22.04-1_amd64:rock
 docker save storage-initializer_v0.10.0-22.04-1_amd64 > storage-initializer_v0.10.0-22.04-1_amd64.tar
 microk8s ctr image import storage-initializer_v0.10.0-22.04-1_amd64.tar
```

### Deploy required charms with relations and configuration
```
juju deploy istio-pilot --trust --channel=1.16/stable --config default-gateway=kubeflow-gateway
juju deploy istio-gateway istio-ingressgateway --channel=1.16/stable --config kind=ingress --trust
juju deploy kserve-controller --trust --channel=0.10/stable --config deployment-mode=rawdeployment --config custom_images='{"configmap__storageInitializer":"storage-initializer_v0.10.0-22.04-1_amd64:rock"}'
juju relate istio-pilot istio-ingressgateway
juju relate kserve-controller istio-pilot
```

### Deploy an inferenceService and make an inference
follow the instructions in https://github.com/canonical/kserve-operators/tree/track/0.10#deploy-a-simple-inferenceservice