### PR TITLE
Add paddle-server ROCK rocraft

### DIFF
--- a/paddle/rockcraft.yaml
+++ b/paddle/rockcraft.yaml
@@ -1,0 +1,64 @@
+# Based on https://github.com/kserve/kserve/blob/release-0.11/python/paddle.Dockerfile
+name: paddle-server
+summary: Paddle server for Kserve deployments
+description: "Kserve Paddle server"
+version: "0.11.0"
+license: Apache-2.0
+base: ubuntu@22.04
+platforms:
+    amd64:
+run-user: _daemon_
+services:
+  paddle-server:
+    override: replace
+    summary: "Paddle server service"
+    startup: enabled
+    command: "python3.10 -m paddleserver [ args ]"
+    environment:
+      PYTHONPATH: /paddleserver:/kserve
+entrypoint-service: paddle-server
+
+parts:
+  security-team-requirement:
+    plugin: nil
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+      dpkg-query --root=${CRAFT_PROJECT_DIR}/../bundles/ubuntu-22.04/rootfs/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
+      > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
+
+  python:
+    plugin: nil
+    source: https://github.com/kserve/kserve.git
+    source-subdir: python
+    source-tag: v0.11.0
+    build-packages:
+    - python3.10
+    overlay-packages:
+    - python3.10
+    - build-essential
+    - libgomp1
+    override-build: |
+      pip install poetry==1.4.0
+      poetry config virtualenvs.create false 
+
+      (cd python/kserve && poetry install --no-interaction)
+
+      (cd python/paddleserver && poetry install --no-interaction)
+      
+      cp -fr python/paddleserver $CRAFT_PART_INSTALL/paddleserver
+      cp -fr python/kserve $CRAFT_PART_INSTALL/kserve
+
+      mkdir -p $CRAFT_PART_INSTALL/usr/local/lib/python3.10/dist-packages
+      mkdir -p $CRAFT_PART_INSTALL/usr/local/share
+      cp -fr /usr/local/lib/python3.10/dist-packages/* $CRAFT_PART_INSTALL/usr/local/lib/python3.10/dist-packages/
+      cp -fr /usr/local/share/* $CRAFT_PART_INSTALL/usr/local/share/
+  
+  third-party:
+    plugin: nil
+    after: [python]
+    source: https://github.com/kserve/kserve.git
+    source-subdir: python
+    source-tag: v0.11.0
+    override-build: |
+      cp -fr third_party/* ${CRAFT_PART_INSTALL}/third_party

--- a/paddle/rockcraft.yaml
+++ b/paddle/rockcraft.yaml
@@ -13,7 +13,7 @@ services:
     override: replace
     summary: "Paddle server service"
     startup: enabled
-    command: "python3.10 -m paddleserver [ args ]"
+    command: "python3.10 -m paddleserver [ ]"
     environment:
       PYTHONPATH: /paddleserver:/kserve
 entrypoint-service: paddle-server

--- a/paddleserver/dummy_pyproject.toml
+++ b/paddleserver/dummy_pyproject.toml
@@ -5,6 +5,7 @@ description = ""
 authors = ["none"]
 
 [tool.poetry.dependencies]
+# This range should match that used upstream: https://github.com/kserve/kserve/blob/v0.11.2/python/paddleserver/pyproject.toml#L13
 python = ">=3.8,<3.11"
 kserve = { path = "../python/kserve", develop = false }
 paddleserver = { path = "../python/paddleserver", develop = false }

--- a/paddleserver/dummy_pyproject.toml
+++ b/paddleserver/dummy_pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 authors = ["none"]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.12"
+python = ">=3.8,<3.11"
 kserve = { path = "../python/kserve", develop = false }
 paddleserver = { path = "../python/paddleserver", develop = false }
 

--- a/paddleserver/dummy_pyproject.toml
+++ b/paddleserver/dummy_pyproject.toml
@@ -1,0 +1,11 @@
+[tool.poetry]
+name = "workaround-for-editable-install"
+version = "0.0.1"
+description = ""
+authors = ["none"]
+
+[tool.poetry.dependencies]
+python = ">=3.8,<3.12"
+kserve = { path = "../python/kserve", develop = false }
+sklearnserver = { path = "../python/paddleserver", develop = false }
+

--- a/paddleserver/dummy_pyproject.toml
+++ b/paddleserver/dummy_pyproject.toml
@@ -7,5 +7,5 @@ authors = ["none"]
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
 kserve = { path = "../python/kserve", develop = false }
-sklearnserver = { path = "../python/paddleserver", develop = false }
+paddleserver = { path = "../python/paddleserver", develop = false }
 

--- a/paddleserver/rockcraft.yaml
+++ b/paddleserver/rockcraft.yaml
@@ -32,8 +32,6 @@ parts:
     source: https://github.com/kserve/kserve.git
     source-subdir: python
     source-tag: v0.11.0
-    build-packages:
-    - python3.10
     overlay-packages:
     - python3.10
     - build-essential

--- a/paddleserver/rockcraft.yaml
+++ b/paddleserver/rockcraft.yaml
@@ -1,4 +1,8 @@
 # Based on https://github.com/kserve/kserve/blob/release-0.11/python/paddle.Dockerfile
+# 
+# See ../CONTRIBUTING.md for more details about the patterns used in this rock. 
+# This rock is implemented with some atypical patterns due to the native of the upstream
+# Dockerfile.
 name: paddleserver
 summary: Paddle server for Kserve deployments
 description: "Kserve Paddle server"
@@ -30,15 +34,13 @@ parts:
     source: https://github.com/kserve/kserve.git
     source-subdir: python
     source-tag: v0.11.0
+    build-packages:
+      - build-essential
+      - libgomp1
     overlay-packages:
-    # We use overlay-packages to get a python3.10 that we can `pip install` packages into.  
-    # For some reason if we do this as a build-package, packages are not installed to the base
-    # python and then doing `poetry config ...` returns as command not found.  
     - python3.10  
     # Including python3-pip here means pip also gets primed for the final rock
     - python3-pip
-    - build-essential
-    - libgomp1
     override-build: |
       # Populate the build system's python environment with all packages needed for 
       # the server in the final rock
@@ -48,26 +50,20 @@ parts:
       poetry config virtualenvs.create false 
 
       # Install the kserve package, this specific server package, and their dependencies.
-      #
-      # Poetry by default installs the root package as editable.  This means the package
-      # is not put into dist-packages, and when we copy dist-packages to the final rock
-      # we will break the kserve/this server's package installs.  
-      # We work around that by installing kserve/this server from a dummy pyproject.toml
-      # that imports these packages as dependencies.
       mkdir -p ./python_env_builddir
       cp -rf $CRAFT_PROJECT_DIR/dummy_pyproject.toml ./python_env_builddir/pyproject.toml
       (cd python_env_builddir && poetry install --no-interaction --no-root)
 
       # Promote the packages we've installed from the local env to the primed image
-      # This doesn't happen automatically from overlay-packages - not sure why
       mkdir -p $CRAFT_PART_INSTALL/usr/local/lib/python3.10/dist-packages
       cp -fr /usr/local/lib/python3.10/dist-packages/* $CRAFT_PART_INSTALL/usr/local/lib/python3.10/dist-packages/
 
-      # TODO: why do we need this?  is this because of the libgomp1?
+      # TODO: why do we need this?
       mkdir -p $CRAFT_PART_INSTALL/usr/local/share
       cp -fr /usr/local/share/* $CRAFT_PART_INSTALL/usr/local/share/
 
-      # Ensure `python` is an executable command in our primed image
+      # Ensure `python` is an executable command in our primed image by making
+      # a symbolic link
       mkdir -p $CRAFT_PART_INSTALL/usr/bin/
       ln -s /usr/bin/python3.10 $CRAFT_PART_INSTALL/usr/bin/python
 

--- a/paddleserver/rockcraft.yaml
+++ b/paddleserver/rockcraft.yaml
@@ -1,5 +1,5 @@
 # Based on https://github.com/kserve/kserve/blob/release-0.11/python/paddle.Dockerfile
-name: paddle-server
+name: paddleserver
 summary: Paddle server for Kserve deployments
 description: "Kserve Paddle server"
 version: "0.11.0"
@@ -9,14 +9,14 @@ platforms:
     amd64:
 run-user: _daemon_
 services:
-  paddle-server:
+  paddleserver:
     override: replace
     summary: "Paddle server service"
     startup: enabled
     command: "python3.10 -m paddleserver [ ]"
     environment:
       PYTHONPATH: /paddleserver:/kserve
-entrypoint-service: paddle-server
+entrypoint-service: paddleserver
 
 parts:
   security-team-requirement:

--- a/paddleserver/rockcraft.yaml
+++ b/paddleserver/rockcraft.yaml
@@ -13,9 +13,7 @@ services:
     override: replace
     summary: "Paddle server service"
     startup: enabled
-    command: "python3.10 -m paddleserver [ ]"
-    environment:
-      PYTHONPATH: /paddleserver:/kserve
+    command: "python -m paddleserver [ ]"
 entrypoint-service: paddleserver
 
 parts:
@@ -33,25 +31,47 @@ parts:
     source-subdir: python
     source-tag: v0.11.0
     overlay-packages:
-    - python3.10
+    # We use overlay-packages to get a python3.10 that we can `pip install` packages into.  
+    # For some reason if we do this as a build-package, packages are not installed to the base
+    # python and then doing `poetry config ...` returns as command not found.  
+    - python3.10  
+    # Including python3-pip here means pip also gets primed for the final rock
+    - python3-pip
     - build-essential
     - libgomp1
     override-build: |
+      # Populate the build system's python environment with all packages needed for 
+      # the server in the final rock
+      
+      # Setup poetry
       pip install poetry==1.4.0
       poetry config virtualenvs.create false 
 
-      (cd python/kserve && poetry install --no-interaction)
+      # Install the kserve package, this specific server package, and their dependencies.
+      #
+      # Poetry by default installs the root package as editable.  This means the package
+      # is not put into dist-packages, and when we copy dist-packages to the final rock
+      # we will break the kserve/this server's package installs.  
+      # We work around that by installing kserve/this server from a dummy pyproject.toml
+      # that imports these packages as dependencies.
+      mkdir -p ./python_env_builddir
+      cp -rf $CRAFT_PROJECT_DIR/dummy_pyproject.toml ./python_env_builddir/pyproject.toml
+      (cd python_env_builddir && poetry install --no-interaction --no-root)
 
-      (cd python/paddleserver && poetry install --no-interaction)
-      
-      cp -fr python/paddleserver $CRAFT_PART_INSTALL/paddleserver
-      cp -fr python/kserve $CRAFT_PART_INSTALL/kserve
-
+      # Promote the packages we've installed from the local env to the primed image
+      # This doesn't happen automatically from overlay-packages - not sure why
       mkdir -p $CRAFT_PART_INSTALL/usr/local/lib/python3.10/dist-packages
-      mkdir -p $CRAFT_PART_INSTALL/usr/local/share
       cp -fr /usr/local/lib/python3.10/dist-packages/* $CRAFT_PART_INSTALL/usr/local/lib/python3.10/dist-packages/
+
+      # TODO: why do we need this?  is this because of the libgomp1?
+      mkdir -p $CRAFT_PART_INSTALL/usr/local/share
       cp -fr /usr/local/share/* $CRAFT_PART_INSTALL/usr/local/share/
-  
+
+      # Ensure `python` is an executable command in our primed image
+      mkdir -p $CRAFT_PART_INSTALL/usr/bin/
+      ln -s /usr/bin/python3.10 $CRAFT_PART_INSTALL/usr/bin/python
+
+  # Copy licenses
   third-party:
     plugin: nil
     after: [python]
@@ -60,3 +80,4 @@ parts:
     source-tag: v0.11.0
     override-build: |
       cp -fr third_party/* ${CRAFT_PART_INSTALL}/third_party
+

--- a/paddleserver/tests/test_rock.py
+++ b/paddleserver/tests/test_rock.py
@@ -1,0 +1,77 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from pathlib import Path
+
+import os
+import logging
+import random
+import pytest
+import string
+import subprocess
+import yaml
+
+from charmed_kubeflow_chisme.rock import CheckRock
+
+
+@pytest.fixture()
+def rock_test_env(tmpdir):
+    """Yields a temporary directory and random docker container name, then cleans them up after."""
+    container_name = "".join(
+        [str(i) for i in random.choices(string.ascii_lowercase, k=8)]
+    )
+    yield tmpdir, container_name
+
+    try:
+        subprocess.run(["docker", "rm", container_name])
+    except Exception:
+        pass
+    # tmpdir fixture we use here should clean up the other files for us
+
+
+@pytest.mark.abort_on_fail
+def test_rock(rock_test_env):
+    """Test rock."""
+    temp_dir, container_name = rock_test_env
+    check_rock = CheckRock("rockcraft.yaml")
+    rock_image = check_rock.get_name()
+    rock_version = check_rock.get_version()
+    LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
+
+    # assert we have the expected files
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /kserve",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /paddleserver",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /third_party",
+        ],
+        check=True,
+    )

--- a/paddleserver/tests/test_rock.py
+++ b/paddleserver/tests/test_rock.py
@@ -47,7 +47,7 @@ def test_rock(rock_test_env):
             "/bin/bash",
             LOCAL_ROCK_IMAGE,
             "-c",
-            "ls -la /kserve",
+            "ls -la /usr/local/lib/python3.10/dist-packages/paddleserver",
         ],
         check=True,
     )
@@ -59,7 +59,7 @@ def test_rock(rock_test_env):
             "/bin/bash",
             LOCAL_ROCK_IMAGE,
             "-c",
-            "ls -la /paddleserver",
+            "ls -la /usr/local/lib/python3.10/dist-packages/kserve",
         ],
         check=True,
     )
@@ -75,3 +75,4 @@ def test_rock(rock_test_env):
         ],
         check=True,
     )
+

--- a/paddleserver/tox.ini
+++ b/paddleserver/tox.ini
@@ -1,0 +1,54 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+[tox]
+skipsdist = True
+skip_missing_interpreters = True
+envlist = pack, export-to-docker, sanity, integration
+
+[testenv]
+setenv =
+    PYTHONPATH={toxinidir}
+    PYTHONBREAKPOINT=ipdb.set_trace
+    CHARM_REPO=https://github.com/canonical/kserve-operators.git
+    CHARM_BRANCH=main
+    LOCAL_CHARM_DIR=charm_repo
+
+[testenv:pack]
+passenv = *
+allowlist_externals =
+    rockcraft
+commands =
+    rockcraft pack
+
+[testenv:export-to-docker]
+passenv = *
+allowlist_externals =
+    bash
+    skopeo
+    yq
+commands =
+    # pack rock and export to docker
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval ".platforms | keys | .[0]" rockcraft.yaml) && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
+             DOCKER_IMAGE=$NAME:$VERSION && \
+             echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
+             skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+
+[testenv:sanity]
+passenv = *
+deps =
+    pytest
+    charmed-kubeflow-chisme
+commands =
+    # run rock tests
+    pytest -s -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
+
+[testenv:integration]
+passenv = *
+allowlist_externals =
+    echo
+commands =
+    # TODO: Implement integration tests here
+    echo "WARNING: This is a placeholder test - no test is implemented here."


### PR DESCRIPTION
Steps to test 
```
cd paddle 
rockcraft clean && rockcraft pack --verbosity=trace
sudo skopeo --insecure-policy copy oci-archive:paddle-server_0.11.0_amd64.rock docker-daemon:charmedkubeflow/paddle-server:0.11.0
docker run charmedkubeflow/paddle-server:0.11.0
```

There should be an output with deprecation warnings like this 
```
2024-02-13T09:37:06.255Z [pebble] Started daemon.
2024-02-13T09:37:06.261Z [pebble] POST /v1/services 5.266914ms 202
2024-02-13T09:37:06.261Z [pebble] Started default services with change 1.
2024-02-13T09:37:06.265Z [pebble] Service "paddle-server" starting: python3.10 -m paddleserver [ args ]
2024-02-13T09:37:07.581Z [paddle-server] /usr/local/lib/python3.10/dist-packages/pkg_resources/__init__.py:121: DeprecationWarning: pkg_resources is deprecated as an API
2024-02-13T09:37:07.581Z [paddle-server]   warnings.warn("pkg_resources is deprecated as an API", DeprecationWarning)
2024-02-13T09:37:07.602Z [paddle-server] /usr/local/lib/python3.10/dist-packages/pkg_resources/__init__.py:2870: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('google')`.
2024-02-13T09:37:07.602Z [paddle-server] Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
2024-02-13T09:37:07.602Z [paddle-server]   declare_namespace(pkg)
2024-02-13T09:37:07.603Z [paddle-server] /usr/local/lib/python3.10/dist-packages/pkg_resources/__init__.py:2870: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('google.cloud')`.
2024-02-13T09:37:07.603Z [paddle-server] Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
2024-02-13T09:37:07.603Z [paddle-server]   declare_namespace(pkg)
2024-02-13T09:37:07.603Z [paddle-server] /usr/local/lib/python3.10/dist-packages/pkg_resources/__init__.py:2349: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('google')`.
2024-02-13T09:37:07.603Z [paddle-server] Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
2024-02-13T09:37:07.603Z [paddle-server]   declare_namespace(parent)
2024-02-13T09:37:07.603Z [paddle-server] /usr/local/lib/python3.10/dist-packages/pkg_resources/__init__.py:2870: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('google.logging')`.
2024-02-13T09:37:07.603Z [paddle-server] Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
2024-02-13T09:37:07.603Z [paddle-server]   declare_namespace(pkg)
2024-02-13T09:37:07.861Z [paddle-server] /usr/local/lib/python3.10/dist-packages/paddle/profiler/profiler_statistic.py:1402: DeprecationWarning: invalid escape sequence '\('
2024-02-13T09:37:07.861Z [paddle-server]   kernel_name_pattern = re.compile('(.+?)(<.*>)(\(.*\))')
2024-02-13T09:37:08.293Z [paddle-server] /usr/local/lib/python3.10/dist-packages/paddle/tensor/random.py:31: DeprecationWarning: invalid escape sequence '\e'
2024-02-13T09:37:08.293Z [paddle-server]   """
2024-02-13T09:37:08.482Z [paddle-server] /usr/local/lib/python3.10/dist-packages/paddle/distributed/parallel.py:87: SyntaxWarning: "is" with a literal. Did you mean "=="?
2024-02-13T09:37:08.482Z [paddle-server]   ) or backend is 'xccl':
2024-02-13T09:37:08.849Z [paddle-server] /usr/local/lib/python3.10/dist-packages/paddle/fluid/contrib/slim/quantization/post_training_quantization.py:438: SyntaxWarning: "is" with a literal. Did you mean "=="?
2024-02-13T09:37:08.849Z [paddle-server]   if self._algo is 'min_max':
2024-02-13T09:37:09.101Z [paddle-server] /usr/local/lib/python3.10/dist-packages/paddle/incubate/nn/layer/fused_linear.py:20: DeprecationWarning: invalid escape sequence '\_'
2024-02-13T09:37:09.101Z [paddle-server]   """
2024-02-13T09:37:09.164Z [paddle-server] /usr/local/lib/python3.10/dist-packages/paddle/distributed/fleet/meta_parallel/sharding/group_sharded_optimizer_stage2.py:208: DeprecationWarning: invalid escape sequence '\.'
2024-02-13T09:37:09.164Z [paddle-server]   "The param name passed to the optimizer doesn't follow .+_[0-9]+\..+ patter, "
2024-02-13T09:37:09.204Z [paddle-server] /usr/local/lib/python3.10/dist-packages/paddle/dataset/common.py:38: DeprecationWarning: invalid escape sequence '\T'
2024-02-13T09:37:09.204Z [paddle-server]   """
2024-02-13T09:37:09.357Z [paddle-server] /usr/local/lib/python3.10/dist-packages/paddle/sparse/unary.py:555: DeprecationWarning: invalid escape sequence '\p'
2024-02-13T09:37:09.357Z [paddle-server]   """
2024-02-13T09:37:09.357Z [paddle-server] /usr/local/lib/python3.10/dist-packages/paddle/sparse/unary.py:588: DeprecationWarning: invalid escape sequence '\p'
2024-02-13T09:37:09.357Z [paddle-server]   """
2024-02-13T09:37:09.362Z [paddle-server] /usr/local/lib/python3.10/dist-packages/paddle/sparse/nn/functional/transformer.py:29: DeprecationWarning: invalid escape sequence '\s'
2024-02-13T09:37:09.362Z [paddle-server]   """
2024-02-13T09:37:09.362Z [paddle-server] /usr/local/lib/python3.10/dist-packages/paddle/sparse/nn/functional/activation.py:64: DeprecationWarning: invalid escape sequence '\e'
2024-02-13T09:37:09.362Z [paddle-server]   """
2024-02-13T09:37:09.362Z [paddle-server] /usr/local/lib/python3.10/dist-packages/paddle/sparse/nn/functional/activation.py:149: DeprecationWarning: invalid escape sequence '\_'
2024-02-13T09:37:09.362Z [paddle-server]   """
2024-02-13T09:37:14.459Z [paddle-server] /usr/local/lib/python3.10/dist-packages/google/rpc/__init__.py:20: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('google.rpc')`.
2024-02-13T09:37:14.459Z [paddle-server] Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
2024-02-13T09:37:14.459Z [paddle-server]   pkg_resources.declare_namespace(__name__)
2024-02-13T09:37:14.459Z [paddle-server] /usr/local/lib/python3.10/dist-packages/pkg_resources/__init__.py:2349: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('google')`.
2024-02-13T09:37:14.459Z [paddle-server] Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
2024-02-13T09:37:14.459Z [paddle-server]   declare_namespace(parent)
2024-02-13T09:37:14.528Z [paddle-server] usage: __main__.py [-h] [--http_port HTTP_PORT] [--grpc_port GRPC_PORT]
2024-02-13T09:37:14.528Z [paddle-server]                    [--workers WORKERS] [--max_threads MAX_THREADS]
2024-02-13T09:37:14.528Z [paddle-server]                    [--max_asyncio_workers MAX_ASYNCIO_WORKERS]
2024-02-13T09:37:14.528Z [paddle-server]                    [--enable_grpc ENABLE_GRPC]
2024-02-13T09:37:14.528Z [paddle-server]                    [--enable_docs_url ENABLE_DOCS_URL]
2024-02-13T09:37:14.528Z [paddle-server]                    [--enable_latency_logging ENABLE_LATENCY_LOGGING]
2024-02-13T09:37:14.528Z [paddle-server]                    [--configure_logging CONFIGURE_LOGGING]
2024-02-13T09:37:14.528Z [paddle-server]                    [--log_config_file LOG_CONFIG_FILE]
2024-02-13T09:37:14.528Z [paddle-server]                    [--access_log_format ACCESS_LOG_FORMAT] --model_dir
2024-02-13T09:37:14.528Z [paddle-server]                    MODEL_DIR [--model_name MODEL_NAME]
2024-02-13T09:37:14.528Z [paddle-server] __main__.py: error: the following arguments are required: --model_dir
```

The output from workload service is identical to upstream container 
```
docker run kserve/paddleserver:v0.11.1
```
