### PR TITLE
add sklearnserver rock

### DIFF
--- a/sklearnserver/dummy_pyproject.toml
+++ b/sklearnserver/dummy_pyproject.toml
@@ -8,3 +8,4 @@ authors = ["none"]
 python = ">=3.8,<3.12"
 kserve = { path = "../python/kserve", develop = false }
 sklearnserver = { path = "../python/sklearnserver", develop = false }
+

--- a/sklearnserver/dummy_pyproject.toml
+++ b/sklearnserver/dummy_pyproject.toml
@@ -1,0 +1,10 @@
+[tool.poetry]
+name = "workaround-for-editable-install"
+version = "0.0.1"
+description = ""
+authors = ["none"]
+
+[tool.poetry.dependencies]
+python = ">=3.8,<3.12"
+kserve = { path = "../python/kserve", develop = false }
+sklearnserver = { path = "../python/sklearnserver", develop = false }

--- a/sklearnserver/rockcraft.yaml
+++ b/sklearnserver/rockcraft.yaml
@@ -47,12 +47,12 @@ parts:
       pip install poetry==1.4.0
       poetry config virtualenvs.create false 
 
-      # Install the kserve and sklearnserver python packages and dependencies.
+      # Install the kserve package, this specific server package, and their dependencies.
       #
       # Poetry by default installs the root package as editable.  This means the package
       # is not put into dist-packages, and when we copy dist-packages to the final rock
-      # we will break the kserve and sklearnserver package installs.  
-      # We work around that by installing kserve and sklearnserver from a dummy pyproject.toml
+      # we will break the kserve/this server's package installs.  
+      # We work around that by installing kserve/this server from a dummy pyproject.toml
       # that imports these packages as dependencies.
       mkdir -p ./python_env_builddir
       cp -rf $CRAFT_PROJECT_DIR/dummy_pyproject.toml ./python_env_builddir/pyproject.toml

--- a/sklearnserver/rockcraft.yaml
+++ b/sklearnserver/rockcraft.yaml
@@ -1,4 +1,8 @@
 # Based on https://github.com/kserve/kserve/blob/release-0.11/python/sklearn.Dockerfile
+# 
+# See ../CONTRIBUTING.md for more details about the patterns used in this rock. 
+# This rock is implemented with some atypical patterns due to the native of the upstream
+# Dockerfile.
 name: sklearnserver
 summary: sklearn server for Kserve deployments
 description: "Kserve sklearn server"
@@ -30,15 +34,13 @@ parts:
     source: https://github.com/kserve/kserve.git
     source-subdir: python
     source-tag: v0.11.0
+    build-packages:
+      - build-essential
+      - libgomp1
     overlay-packages:
-    # We use overlay-packages to get a python3.10 that we can `pip install` packages into.  
-    # For some reason if we do this as a build-package, packages are not installed to the base
-    # python and then doing `poetry config ...` returns as command not found.  
     - python3.10  
     # Including python3-pip here means pip also gets primed for the final rock
     - python3-pip
-    - build-essential
-    - libgomp1
     override-build: |
       # Populate the build system's python environment with all packages needed for 
       # the server in the final rock
@@ -48,26 +50,20 @@ parts:
       poetry config virtualenvs.create false 
 
       # Install the kserve package, this specific server package, and their dependencies.
-      #
-      # Poetry by default installs the root package as editable.  This means the package
-      # is not put into dist-packages, and when we copy dist-packages to the final rock
-      # we will break the kserve/this server's package installs.  
-      # We work around that by installing kserve/this server from a dummy pyproject.toml
-      # that imports these packages as dependencies.
       mkdir -p ./python_env_builddir
       cp -rf $CRAFT_PROJECT_DIR/dummy_pyproject.toml ./python_env_builddir/pyproject.toml
       (cd python_env_builddir && poetry install --no-interaction --no-root)
 
       # Promote the packages we've installed from the local env to the primed image
-      # This doesn't happen automatically from overlay-packages - not sure why
       mkdir -p $CRAFT_PART_INSTALL/usr/local/lib/python3.10/dist-packages
       cp -fr /usr/local/lib/python3.10/dist-packages/* $CRAFT_PART_INSTALL/usr/local/lib/python3.10/dist-packages/
 
-      # TODO: why do we need this?  is this because of the libgomp1?
+      # TODO: why do we need this?
       mkdir -p $CRAFT_PART_INSTALL/usr/local/share
       cp -fr /usr/local/share/* $CRAFT_PART_INSTALL/usr/local/share/
 
-      # Ensure `python` is an executable command in our primed image
+      # Ensure `python` is an executable command in our primed image by making
+      # a symbolic link
       mkdir -p $CRAFT_PART_INSTALL/usr/bin/
       ln -s /usr/bin/python3.10 $CRAFT_PART_INSTALL/usr/bin/python
 

--- a/sklearnserver/rockcraft.yaml
+++ b/sklearnserver/rockcraft.yaml
@@ -80,3 +80,4 @@ parts:
     source-tag: v0.11.0
     override-build: |
       cp -fr third_party/* ${CRAFT_PART_INSTALL}/third_party
+

--- a/sklearnserver/rockcraft.yaml
+++ b/sklearnserver/rockcraft.yaml
@@ -1,0 +1,82 @@
+# Based on https://github.com/kserve/kserve/blob/release-0.11/python/sklearn.Dockerfile
+name: sklearnserver
+summary: sklearn server for Kserve deployments
+description: "Kserve sklearn server"
+version: "0.11.0"
+license: Apache-2.0
+base: ubuntu@22.04
+platforms:
+    amd64:
+run-user: _daemon_
+services:
+  sklearnserver:
+    override: replace
+    summary: "sklearn server service"
+    startup: enabled
+    command: "python -m sklearnserver [ ]"
+entrypoint-service: sklearnserver
+
+parts:
+  security-team-requirement:
+    plugin: nil
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+      dpkg-query --root=${CRAFT_PROJECT_DIR}/../bundles/ubuntu-22.04/rootfs/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
+      > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
+
+  python:
+    plugin: nil
+    source: https://github.com/kserve/kserve.git
+    source-subdir: python
+    source-tag: v0.11.0
+    overlay-packages:
+    # We use overlay-packages to get a python3.10 that we can `pip install` packages into.  
+    # For some reason if we do this as a build-package, packages are not installed to the base
+    # python and then doing `poetry config ...` returns as command not found.  
+    - python3.10  
+    # Including python3-pip here means pip also gets primed for the final rock
+    - python3-pip
+    - build-essential
+    - libgomp1
+    override-build: |
+      # Populate the build system's python environment with all packages needed for 
+      # the server in the final rock
+      
+      # Setup poetry
+      pip install poetry==1.4.0
+      poetry config virtualenvs.create false 
+
+      # Install the kserve and sklearnserver python packages and dependencies.
+      #
+      # Poetry by default installs the root package as editable.  This means the package
+      # is not put into dist-packages, and when we copy dist-packages to the final rock
+      # we will break the kserve and sklearnserver package installs.  
+      # We work around that by installing kserve and sklearnserver from a dummy pyproject.toml
+      # that imports these packages as dependencies.
+      mkdir -p ./python_env_builddir
+      cp -rf $CRAFT_PROJECT_DIR/dummy_pyproject.toml ./python_env_builddir/pyproject.toml
+      (cd python_env_builddir && poetry install --no-interaction --no-root)
+
+      # Promote the packages we've installed from the local env to the primed image
+      # This doesn't happen automatically from overlay-packages - not sure why
+      mkdir -p $CRAFT_PART_INSTALL/usr/local/lib/python3.10/dist-packages
+      cp -fr /usr/local/lib/python3.10/dist-packages/* $CRAFT_PART_INSTALL/usr/local/lib/python3.10/dist-packages/
+
+      # TODO: why do we need this?  is this because of the libgomp1?
+      mkdir -p $CRAFT_PART_INSTALL/usr/local/share
+      cp -fr /usr/local/share/* $CRAFT_PART_INSTALL/usr/local/share/
+
+      # Ensure `python` is an executable command in our primed image
+      mkdir -p $CRAFT_PART_INSTALL/usr/bin/
+      ln -s /usr/bin/python3.10 $CRAFT_PART_INSTALL/usr/bin/python
+
+  # Copy licenses
+  third-party:
+    plugin: nil
+    after: [python]
+    source: https://github.com/kserve/kserve.git
+    source-subdir: python
+    source-tag: v0.11.0
+    override-build: |
+      cp -fr third_party/* ${CRAFT_PART_INSTALL}/third_party

--- a/sklearnserver/tests/test_rock.py
+++ b/sklearnserver/tests/test_rock.py
@@ -1,0 +1,65 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from pathlib import Path
+
+import os
+import logging
+import random
+import pytest
+import string
+import subprocess
+import yaml
+
+from charmed_kubeflow_chisme.rock import CheckRock
+
+
+@pytest.fixture()
+def rock_test_env(tmpdir):
+    """Yields a temporary directory and random docker container name, then cleans them up after."""
+    container_name = "".join(
+        [str(i) for i in random.choices(string.ascii_lowercase, k=8)]
+    )
+    yield tmpdir, container_name
+
+    try:
+        subprocess.run(["docker", "rm", container_name])
+    except Exception:
+        pass
+    # tmpdir fixture we use here should clean up the other files for us
+
+
+@pytest.mark.abort_on_fail
+def test_rock(rock_test_env):
+    """Test rock."""
+    temp_dir, container_name = rock_test_env
+    check_rock = CheckRock("rockcraft.yaml")
+    rock_image = check_rock.get_name()
+    rock_version = check_rock.get_version()
+    LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
+
+    # assert we have the expected files
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /usr/local/lib/python3.10/dist-packages/sklearnserver",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /usr/local/lib/python3.10/dist-packages/kserve",
+        ],
+        check=True,
+    )

--- a/sklearnserver/tests/test_rock.py
+++ b/sklearnserver/tests/test_rock.py
@@ -63,3 +63,16 @@ def test_rock(rock_test_env):
         ],
         check=True,
     )
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /third_party",
+        ],
+        check=True,
+    )
+

--- a/sklearnserver/tox.ini
+++ b/sklearnserver/tox.ini
@@ -1,0 +1,54 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+[tox]
+skipsdist = True
+skip_missing_interpreters = True
+envlist = pack, export-to-docker, sanity, integration
+
+[testenv]
+setenv =
+    PYTHONPATH={toxinidir}
+    PYTHONBREAKPOINT=ipdb.set_trace
+    CHARM_REPO=https://github.com/canonical/kserve-operators.git
+    CHARM_BRANCH=main
+    LOCAL_CHARM_DIR=charm_repo
+
+[testenv:pack]
+passenv = *
+allowlist_externals =
+    rockcraft
+commands =
+    rockcraft pack
+
+[testenv:export-to-docker]
+passenv = *
+allowlist_externals =
+    bash
+    skopeo
+    yq
+commands =
+    # pack rock and export to docker
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval ".platforms | keys | .[0]" rockcraft.yaml) && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
+             DOCKER_IMAGE=$NAME:$VERSION && \
+             echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
+             skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+
+[testenv:sanity]
+passenv = *
+deps =
+    pytest
+    charmed-kubeflow-chisme
+commands =
+    # run rock tests
+    pytest -s -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
+
+[testenv:integration]
+passenv = *
+allowlist_externals =
+    echo
+commands =
+    # TODO: Implement integration tests here
+    echo "WARNING: This is a placeholder test - no test is implemented here."


### PR DESCRIPTION
adds a rock for the kserve v0.11 sklearnserver based on [this dockerfile](https://github.com/kserve/kserve/blob/release-0.11/python/sklearn.Dockerfile) and the existing Paddle and pmmlserver rocks

This PR refactors a little compared to the previous rocks like pmmlserver.  The main goals were:
* improve readability (the pmmlserver uses a lot of magic but doesn't explain why/how it works - I've tried to add comments here)
* make the image API interchangable with upstream as much as possible (no need for pythonpath or calling `python3`)

Specifically for the `pythonpath`, the [pmmlserver rock](https://github.com/canonical/kserve-rocks/blob/main/pmmlserver/rockcraft.yaml#L19C1-L20C1) needs to add `/pmmlserver:/kserve` to its service `PYTHONPATH` because poetry by default installs a root project **as editable**, which means the code is not stored in `dist-packages` like the other installed packages.  So when we copy our installed python packages from build env to the final rock in pmmlserver, we omit the pmmlserver and kserve packages (and then we "fix" that by copying the code separately, and adding the new code dirs to `PYTHONPATH`.  

I'm worried this `PYTHONPATH` workaround might have unintended consequences, so instead in this rock I install kserve and sklearnserver packages as local dependencies of a dummy poetry project rather than as root projects.  This tricks poetry into installing them normally (not editable), which means they are put in `dist-packages` like everything else. 

### Testing instructions

```
cd sklearnserver
rockcraft pack
sudo skopeo --insecure-policy copy oci-archive:sklearnserver_0.11.0_amd64.rock docker-daemon:charmedkubeflow/sklearnserver:0.11.0
docker run charmedkubeflow/sklearnserver:0.11.0
```

The rock should launch, but then fail with:
> 2024-02-15T20:42:59.351Z [sklearnserver] __main__.py: error: the following arguments are required: --model_dir
