### PR TITLE
add libgomp1 to paddleserver rock

### DIFF
--- a/paddleserver/rockcraft.yaml
+++ b/paddleserver/rockcraft.yaml
@@ -37,6 +37,8 @@ parts:
     build-packages:
       - build-essential
       - libgomp1
+    stage-packages:
+      - libgomp1
     overlay-packages:
     - python3.10  
     # Including python3-pip here means pip also gets primed for the final rock


### PR DESCRIPTION
Fixes #28 

### Test instructions:
```
# Install the gcloud CLI tool: https://cloud.google.com/sdk/docs/install

# download the model locally
gsutil cp -r gs://kfserving-examples/models/paddle/resnet ./sample_model/

# Build the rock and put it to docker
tox -e pack
tox -e export-to-docker

# mount the model into the container at runtime
docker run -v PATH_TO/sample_model:/mnt/models PADDLESERVER_IMAGE --model_name paddle-resnet50 --model_dir=/mnt/models/resnet --http_port=8080
```