### PR TITLE
bump sklearnserver rock to 0.11.2

### DIFF
--- a/sklearnserver/README.md
+++ b/sklearnserver/README.md
@@ -1,0 +1,39 @@
+## Testing instructions
+
+From the [upstream usage example](https://kserve.github.io/website/master/modelserving/v1beta1/sklearn/v2/#deploy-the-model-with-rest-endpoint-through-inferenceservice/), this rock can be tested locally using:
+
+Launch the server with:
+```
+# download the model locally
+gsutil cp -r gs://kfserving-examples/models/sklearn/1.0/model ./sample_model/
+
+# mount the model into the container at runtime
+docker run -p 8080:8080 -v $(pwd)/sample_model:/mnt/models sklearnserver:0.11.2 --model_name test_model --model_dir=/mnt/models --http_port=8080
+
+```
+
+Test the server with:
+```
+cat <<EOF >> iris-input-v2.json
+{
+  "inputs": [
+    {
+      "name": "input-0",
+      "shape": [2, 4],
+      "datatype": "FP32",
+      "data": [
+        [6.8, 2.8, 4.8, 1.4],
+        [6.0, 3.4, 4.5, 1.6]
+      ]
+    }
+  ]
+}
+EOF
+
+curl -v \
+  -H "Content-Type: application/json" \
+  -d @./iris-input-v2.json \
+  localhost:8080/v2/models/test_model/infer
+```
+
+which should return the expected output described in the docs.  

--- a/sklearnserver/README.md
+++ b/sklearnserver/README.md
@@ -1,4 +1,11 @@
-## Testing instructions
+## Testing
+
+### Prerequisites
+
+* docker
+* Google Cloud CLI tools ([installation guide](https://cloud.google.com/sdk/docs/install))
+
+### Instructions
 
 From the [upstream usage example](https://kserve.github.io/website/master/modelserving/v1beta1/sklearn/v2/#deploy-the-model-with-rest-endpoint-through-inferenceservice/), this rock can be tested locally using:
 

--- a/sklearnserver/README.md
+++ b/sklearnserver/README.md
@@ -9,7 +9,7 @@ mkdir sample_model
 gsutil cp -r gs://kfserving-examples/models/sklearn/1.0/model ./sample_model/
 
 # mount the model into the container at runtime
-docker run -p 8080:8080 -v $(pwd)/sample_model:/mnt/models sklearnserver:0.11.2 --model_name test_model --model_dir=/mnt/models --http_port=8080
+docker run -p 8080:8080 -v $(pwd)/sample_model:/mnt/models sklearnserver:<version> --model_name test_model --model_dir=/mnt/models --http_port=8080
 
 ```
 

--- a/sklearnserver/README.md
+++ b/sklearnserver/README.md
@@ -5,6 +5,7 @@ From the [upstream usage example](https://kserve.github.io/website/master/models
 Launch the server with:
 ```
 # download the model locally
+mkdir sample_model
 gsutil cp -r gs://kfserving-examples/models/sklearn/1.0/model ./sample_model/
 
 # mount the model into the container at runtime

--- a/sklearnserver/rockcraft.yaml
+++ b/sklearnserver/rockcraft.yaml
@@ -6,7 +6,7 @@
 name: sklearnserver
 summary: sklearn server for Kserve deployments
 description: "Kserve sklearn server"
-version: "0.11.0"
+version: "0.11.2"
 license: Apache-2.0
 base: ubuntu@22.04
 platforms:
@@ -33,7 +33,7 @@ parts:
     plugin: nil
     source: https://github.com/kserve/kserve.git
     source-subdir: python
-    source-tag: v0.11.0
+    source-tag: v0.11.2
     build-packages:
       - build-essential
       - libgomp1
@@ -73,7 +73,7 @@ parts:
     after: [python]
     source: https://github.com/kserve/kserve.git
     source-subdir: python
-    source-tag: v0.11.0
+    source-tag: v0.11.2
     override-build: |
       cp -fr third_party/* ${CRAFT_PART_INSTALL}/third_party
 


### PR DESCRIPTION
closes #35 

### Tester instructions

Launch the server with:
```
# download the model locally
gsutil cp -r gs://kfserving-examples/models/sklearn/1.0/model ./sample_model/

# mount the model into the container at runtime
docker run -p 8080:8080 -v $(pwd)/sample_model:/mnt/models sklearnserver:0.11.2 --model_name test_model --model_dir=/mnt/models --http_port=8080

```

Test the server with:
```
cat <<EOF >> iris-input-v2.json
{
  "inputs": [
    {
      "name": "input-0",
      "shape": [2, 4],
      "datatype": "FP32",
      "data": [
        [6.8, 2.8, 4.8, 1.4],
        [6.0, 3.4, 4.5, 1.6]
      ]
    }
  ]
}
EOF

curl -v \
  -H "Content-Type: application/json" \
  -d @./iris-input-v2.json \
  localhost:8080/v2/models/test_model/infer
```