### PR TITLE
bump paddleserver to 0.11.2, add testing instructions

### DIFF
--- a/paddleserver/README.md
+++ b/paddleserver/README.md
@@ -1,0 +1,26 @@
+## Testing instructions
+
+From the [upstream usage example](https://kserve.github.io/website/master/modelserving/v1beta1/paddle/), this rock can be tested locally using:
+
+Launch the server with:
+```
+# download the model locally
+mkdir sample_model
+gsutil cp -r gs://kfserving-examples/models/paddle/resnet ./sample_model/
+
+# mount the model into the container at runtime
+docker run -p 8080:8080 -v $(pwd)/sample_model/resnet:/mnt/models paddleserver:0.11.2 --model_name test_model --model_dir=/mnt/models --http_port=8080
+
+```
+
+Test the server with:
+```
+wget https://kserve.github.io/website/master/modelserving/v1beta1/paddle/jay.json -O input.json
+
+curl -v
+  -H "Content-Type: application/json" \
+  -d @./input.json \
+  localhost:8080/v1/models/test_model:predict
+```
+
+which should return the expected output described in the docs.  

--- a/paddleserver/README.md
+++ b/paddleserver/README.md
@@ -1,4 +1,11 @@
-## Testing instructions
+## Testing
+
+### Prerequisites
+
+* docker
+* Google Cloud CLI tools ([installation guide](https://cloud.google.com/sdk/docs/install))
+
+### Instructions
 
 From the [upstream usage example](https://kserve.github.io/website/master/modelserving/v1beta1/paddle/), this rock can be tested locally using:
 
@@ -9,7 +16,7 @@ mkdir sample_model
 gsutil cp -r gs://kfserving-examples/models/paddle/resnet ./sample_model/
 
 # mount the model into the container at runtime
-docker run -p 8080:8080 -v $(pwd)/sample_model/resnet:/mnt/models paddleserver:0.11.2 --model_name test_model --model_dir=/mnt/models --http_port=8080
+docker run -p 8080:8080 -v $(pwd)/sample_model/resnet:/mnt/models paddleserver:<version> --model_name test_model --model_dir=/mnt/models --http_port=8080
 
 ```
 

--- a/paddleserver/rockcraft.yaml
+++ b/paddleserver/rockcraft.yaml
@@ -6,7 +6,7 @@
 name: paddleserver
 summary: Paddle server for Kserve deployments
 description: "Kserve Paddle server"
-version: "0.11.0"
+version: "0.11.2"
 license: Apache-2.0
 base: ubuntu@22.04
 platforms:
@@ -33,7 +33,7 @@ parts:
     plugin: nil
     source: https://github.com/kserve/kserve.git
     source-subdir: python
-    source-tag: v0.11.0
+    source-tag: v0.11.2
     build-packages:
       - build-essential
       - libgomp1
@@ -75,7 +75,7 @@ parts:
     after: [python]
     source: https://github.com/kserve/kserve.git
     source-subdir: python
-    source-tag: v0.11.0
+    source-tag: v0.11.2
     override-build: |
       cp -fr third_party/* ${CRAFT_PART_INSTALL}/third_party
 


### PR DESCRIPTION
closes #39 

## Testing instructions

See instructions in `./paddleserver/README.md`