### PR TITLE
Update pmmlserver v0.12.1

### DIFF
--- a/pmmlserver/rockcraft.yaml
+++ b/pmmlserver/rockcraft.yaml
@@ -1,4 +1,4 @@
-# Based on https://github.com/kserve/kserve/blob/release-0.11/python/pmml.Dockerfile
+# Based on https://github.com/kserve/kserve/blob/v0.12.1/python/pmml.Dockerfile
 # 
 # See ../CONTRIBUTING.md for more details about the patterns used in this rock. 
 # This rock is implemented with some atypical patterns due to the native of the upstream
@@ -6,7 +6,7 @@
 name: pmmlserver
 summary: Pmml server for Kserve deployments
 description: "Kserve Pmml server"
-version: "0.11.2"
+version: "0.12.1"
 license: Apache-2.0
 base: ubuntu@22.04
 platforms:
@@ -43,7 +43,7 @@ parts:
     plugin: nil
     source: https://github.com/kserve/kserve.git
     source-subdir: python
-    source-tag: v0.11.2
+    source-tag: v0.12.1
     build-packages:
       - build-essential
       - libgomp1
@@ -56,7 +56,7 @@ parts:
       # the server in the final rock
       
       # Setup poetry
-      pip install poetry==1.4.0
+      pip install poetry==1.7.1
       poetry config virtualenvs.create false 
 
       # Install the kserve package, this specific server package, and their dependencies.
@@ -83,7 +83,7 @@ parts:
     after: [python]
     source: https://github.com/kserve/kserve.git
     source-subdir: python
-    source-tag: v0.11.2
+    source-tag: v0.12.1
     override-build: |
       cp -fr third_party/* ${CRAFT_PART_INSTALL}/third_party
 


### PR DESCRIPTION
Closes: https://github.com/canonical/kserve-rocks/issues/53

I have compared this file: https://github.com/kserve/kserve/blob/v0.12.1/python/pmml.Dockerfile for tags `v0.11.2` and `v0.12.1`

Changes: 
- poetry version