### PR TITLE
Update controller rock v0.12.1

### DIFF
--- a/controller/rockcraft.yaml
+++ b/controller/rockcraft.yaml
@@ -1,8 +1,8 @@
-# Dockerfile https://github.com/kserve/kserve/blob/v0.11.2/Dockerfile
+# Based on https://github.com/kserve/kserve/blob/v0.12.1/Dockerfile
 name: kserve-controller
 summary: KServe controller
 description: "KServe controller manager"
-version: "0.11.2"
+version: "0.12.1"
 license: Apache-2.0
 base: ubuntu@22.04
 platforms:
@@ -29,9 +29,9 @@ parts:
     plugin: go
     source: https://github.com/kserve/kserve
     source-type: git
-    source-tag: v0.11.2
+    source-tag: v0.12.1
     build-snaps:
-      - go/1.20/stable
+      - go/1.21/stable
     build-environment:
       - CGO_ENABLED: 0
       - GOOS: linux


### PR DESCRIPTION
Closes: https://github.com/canonical/kserve-rocks/issues/51

I have compared tags `v0.12.1` and `v0.11.2` for [this](https://github.com/kserve/kserve/blob/v0.12.1/Dockerfile) file 

Changes: 
- Go version bump