### PR TITLE
Update agent rock v0.12.1

### DIFF
--- a/agent/rockcraft.yaml
+++ b/agent/rockcraft.yaml
@@ -1,8 +1,8 @@
-# Dockerfile https://github.com/kserve/kserve/blob/v0.11.2/agent.Dockerfile
+# Dockerfile https://github.com/kserve/kserve/blob/v0.12.1/agent.Dockerfile
 name: kserve-agent
 summary: KServe agent
 description: "KServe model agent"
-version: "0.11.2"
+version: "0.12.1"
 license: Apache-2.0
 base: ubuntu@22.04
 platforms:
@@ -29,9 +29,9 @@ parts:
     plugin: go
     source: https://github.com/kserve/kserve
     source-type: git
-    source-tag: v0.11.2
+    source-tag: v0.12.1
     build-snaps:
-      - go/1.20/stable
+      - go/1.21/stable
     build-environment:
       - CGO_ENABLED: 0
       - GOOS: linux

--- a/agent/rockcraft.yaml
+++ b/agent/rockcraft.yaml
@@ -1,4 +1,4 @@
-# Dockerfile https://github.com/kserve/kserve/blob/v0.12.1/agent.Dockerfile
+# Based on https://github.com/kserve/kserve/blob/v0.12.1/agent.Dockerfile
 name: kserve-agent
 summary: KServe agent
 description: "KServe model agent"


### PR DESCRIPTION
Closes: https://github.com/canonical/kserve-rocks/issues/58

I have compared tags `v0.12.1` and `v0.11.2` for [this](https://github.com/kserve/kserve/blob/v0.12.1/agent.Dockerfile) file 

Changes: 
- Go version bump