### PR TITLE
Update storage-initializer rock v0.12.1

### DIFF
--- a/storage-initializer/rockcraft.yaml
+++ b/storage-initializer/rockcraft.yaml
@@ -1,11 +1,11 @@
-# Based on https://github.com/kserve/kserve/blob/master/python/storage-initializer.Dockerfile
+# Based on https://github.com/kserve/kserve/blob/v0.12.1/python/storage-initializer.Dockerfile
 #
 # See ../CONTRIBUTING.md for more details about the patterns used in this rock.
 # This rock is implemented with some atypical patterns due to the native of the upstream
 name: storage-initializer
 summary: Storage initializer for Kserve deployments
 description: "Kserve storage initializer"
-version: "0.11.2"
+version: "0.12.1"
 license: Apache-2.0
 base: ubuntu@22.04
 platforms:
@@ -38,7 +38,7 @@ parts:
   python:
     plugin: nil
     source: https://github.com/kserve/kserve.git
-    source-tag: v0.11.2
+    source-tag: v0.12.1
     build-packages:
     - gcc
     - libkrb5-dev
@@ -86,7 +86,7 @@ parts:
     after: [python]
     source: https://github.com/kserve/kserve.git
     source-subdir: python
-    source-tag: v0.11.2
+    source-tag: v0.12.1
     override-build: |
       cp -fr third_party/* ${CRAFT_PART_INSTALL}/third_party
 


### PR DESCRIPTION
Closes: https://github.com/canonical/kserve-rocks/issues/52

I have compared tags `v0.12.1` and `v0.11.2` for [this](https://github.com/kserve/kserve/blob/v0.12.1/python/storage-initializer.Dockerfile) file 

**Note:** for v0.12.1 the only change was poetry version which was already correctly set (maybe some misstake during previous PR). I have just updated the tags and the comments.