### PR TITLE
Update `storage-initializer` to `v0.13.0`

### DIFF
--- a/storage-initializer/rockcraft.yaml
+++ b/storage-initializer/rockcraft.yaml
@@ -1,11 +1,11 @@
-# Based on https://github.com/kserve/kserve/blob/v0.12.1/python/storage-initializer.Dockerfile
+# Based on https://github.com/kserve/kserve/blob/v0.13.0/python/storage-initializer.Dockerfile
 #
 # See ../CONTRIBUTING.md for more details about the patterns used in this rock.
 # This rock is implemented with some atypical patterns due to the native of the upstream
 name: storage-initializer
 summary: Storage initializer for Kserve deployments
 description: "Kserve storage initializer"
-version: "0.12.1"
+version: "0.13.0"
 license: Apache-2.0
 base: ubuntu@22.04
 platforms:
@@ -38,7 +38,7 @@ parts:
   python:
     plugin: nil
     source: https://github.com/kserve/kserve.git
-    source-tag: v0.12.1
+    source-tag: v0.13.0
     build-packages:
     - gcc
     - libkrb5-dev
@@ -86,7 +86,7 @@ parts:
     after: [python]
     source: https://github.com/kserve/kserve.git
     source-subdir: python
-    source-tag: v0.12.1
+    source-tag: v0.13.0
     override-build: |
       cp -fr third_party/* ${CRAFT_PART_INSTALL}/third_party
 


### PR DESCRIPTION
Closes: https://github.com/canonical/kserve-rocks/issues/81

I have compared tags `0.12.1` and `0.13.0` for this file https://github.com/kserve/kserve/blob/v0.13.0/python/storage-initializer.Dockerfile