### PR TITLE
Update xgb server for v0.13.0

### DIFF
--- a/xgbserver/rockcraft.yaml
+++ b/xgbserver/rockcraft.yaml
@@ -1,4 +1,4 @@
-# Based on https://github.com/kserve/kserve/blob/master/python/xgb.Dockerfile
+# Based on https://github.com/kserve/kserve/blob/v0.13.0/python/xgb.Dockerfile
 # 
 # See ../CONTRIBUTING.md for more details about the patterns used in this rock. 
 # This rock is implemented with some atypical patterns due to the native of the upstream
@@ -6,7 +6,7 @@
 name: xgbserver
 summary: xgboost server for Kserve deployments
 description: "Kserve xgboost server"
-version: "0.11.2"
+version: "0.13.0"
 license: Apache-2.0
 base: ubuntu@22.04
 platforms:
@@ -33,7 +33,7 @@ parts:
     plugin: nil
     source: https://github.com/kserve/kserve.git
     source-subdir: python
-    source-tag: v0.11.2
+    source-tag: v0.13.0
     build-packages:
       - libgomp1
     overlay-packages:
@@ -45,7 +45,7 @@ parts:
       # the server in the final rock
       
       # Setup poetry
-      pip install poetry==1.4.0
+      pip install poetry==1.7.1
       poetry config virtualenvs.create false 
 
       # Install the kserve package, this specific server package, and their dependencies.
@@ -72,7 +72,7 @@ parts:
     after: [python]
     source: https://github.com/kserve/kserve.git
     source-subdir: python
-    source-tag: v0.11.2
+    source-tag: v0.13.0
     override-build: |
       cp -fr third_party/* ${CRAFT_PART_INSTALL}/third_party
 


### PR DESCRIPTION
Closes: https://github.com/canonical/kserve-rocks/issues/57

I have compared tags `0.11.2` and `0.13.0` for this file https://github.com/kserve/kserve/blob/v0.13.0/python/xgb.Dockerfile

Changes:
- poetry bump