### PR TITLE
Added `artexplainer` rock and tests

### DIFF
--- a/artexplainer/dummy_pyproject.toml
+++ b/artexplainer/dummy_pyproject.toml
@@ -1,0 +1,11 @@
+[tool.poetry]
+name = "workaround-for-editable-install"
+version = "0.0.1"
+description = ""
+authors = ["none"]
+
+[tool.poetry.dependencies]
+# This range should match that used upstream: https://github.com/kserve/kserve/blob/v0.11.2/python/artexplainer/pyproject.toml#L13
+python = ">=3.9,<3.12"
+kserve = { path = "../python/kserve", develop = false }
+artserver = { path = "../python/artexplainer", develop = false }

--- a/artexplainer/rockcraft.yaml
+++ b/artexplainer/rockcraft.yaml
@@ -1,0 +1,72 @@
+# Based on https://github.com/kserve/kserve/blob/v0.13.0/python/artexplainer.Dockerfile
+#
+# See ../CONTRIBUTING.md for more details about the patterns used in this rock.
+# This rock is implemented with some atypical patterns due to the native of the upstream
+# Dockerfile.
+name: artexplainer
+summary: Art server for Kserve deployments
+description: "Kserve Art server"
+version: "0.13.0"
+license: Apache-2.0
+base: ubuntu@22.04
+run-user: _daemon_
+platforms:
+    amd64:
+services:
+  artserver:
+    override: replace
+    summary: "Art server service"
+    startup: enabled
+    command: "python -m artserver [ ]"
+entrypoint-service: artserver
+
+parts:
+  security-team-requirement:
+    plugin: nil
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+      dpkg-query --root=${CRAFT_PROJECT_DIR}/../bundles/ubuntu-22.04/rootfs/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
+      > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
+
+  python:
+    plugin: nil
+    source: https://github.com/kserve/kserve.git
+    source-subdir: python
+    source-tag: v0.13.0
+    build-packages:
+      - build-essential
+      - libgomp1
+    overlay-packages:
+    - python3.10
+    - python3-pip
+    override-build: |
+      pip install poetry==1.7.1
+      poetry config virtualenvs.create false 
+
+      # Install the kserve package, this specific server package, and their dependencies.
+      mkdir -p ./python_env_builddir
+      cp -rf $CRAFT_PROJECT_DIR/dummy_pyproject.toml ./python_env_builddir/pyproject.toml
+      (cd python_env_builddir && poetry install --no-interaction --no-root)
+
+      # Promote the packages we've installed from the local env to the primed image
+      mkdir -p $CRAFT_PART_INSTALL/usr/local/lib/python3.10/dist-packages
+      cp -fr /usr/local/lib/python3.10/dist-packages/* $CRAFT_PART_INSTALL/usr/local/lib/python3.10/dist-packages/
+
+      mkdir -p $CRAFT_PART_INSTALL/usr/local/share
+      cp -fr /usr/local/share/* $CRAFT_PART_INSTALL/usr/local/share/
+
+      # Ensure `python` is an executable command in our primed image by making
+      # a symbolic link
+      mkdir -p $CRAFT_PART_INSTALL/usr/bin/
+      ln -s /usr/bin/python3.10 $CRAFT_PART_INSTALL/usr/bin/python
+
+  # Copy licenses
+  third-party:
+    plugin: nil
+    after: [python]
+    source: https://github.com/kserve/kserve.git
+    source-subdir: python
+    source-tag: v0.13.0
+    override-build: |
+      cp -fr third_party/* ${CRAFT_PART_INSTALL}/third_party

--- a/artexplainer/tests/test_rock.py
+++ b/artexplainer/tests/test_rock.py
@@ -12,7 +12,6 @@ from charmed_kubeflow_chisme.rock import CheckRock
 @pytest.mark.abort_on_fail
 def test_rock():
     """Test rock."""
-    temp_dir, container_name = rock_test_env
     check_rock = CheckRock("rockcraft.yaml")
     rock_image = check_rock.get_name()
     rock_version = check_rock.get_version()

--- a/artexplainer/tests/test_rock.py
+++ b/artexplainer/tests/test_rock.py
@@ -1,0 +1,58 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import random
+import pytest
+import string
+import subprocess
+
+from charmed_kubeflow_chisme.rock import CheckRock
+
+
+@pytest.mark.abort_on_fail
+def test_rock(rock_test_env):
+    """Test rock."""
+    temp_dir, container_name = rock_test_env
+    check_rock = CheckRock("rockcraft.yaml")
+    rock_image = check_rock.get_name()
+    rock_version = check_rock.get_version()
+    LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
+
+    # assert we have the expected files
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /usr/local/lib/python3.10/dist-packages/artserver",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /usr/local/lib/python3.10/dist-packages/kserve",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /third_party",
+        ],
+        check=True,
+    )
+

--- a/artexplainer/tests/test_rock.py
+++ b/artexplainer/tests/test_rock.py
@@ -10,7 +10,7 @@ from charmed_kubeflow_chisme.rock import CheckRock
 
 
 @pytest.mark.abort_on_fail
-def test_rock(rock_test_env):
+def test_rock():
     """Test rock."""
     temp_dir, container_name = rock_test_env
     check_rock = CheckRock("rockcraft.yaml")

--- a/artexplainer/tox.ini
+++ b/artexplainer/tox.ini
@@ -1,0 +1,54 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+[tox]
+skipsdist = True
+skip_missing_interpreters = True
+envlist = pack, export-to-docker, sanity, integration
+
+[testenv]
+setenv =
+    PYTHONPATH={toxinidir}
+    PYTHONBREAKPOINT=ipdb.set_trace
+    CHARM_REPO=https://github.com/canonical/kserve-operators.git
+    CHARM_BRANCH=main
+    LOCAL_CHARM_DIR=charm_repo
+
+[testenv:pack]
+passenv = *
+allowlist_externals =
+    rockcraft
+commands =
+    rockcraft pack
+
+[testenv:export-to-docker]
+passenv = *
+allowlist_externals =
+    bash
+    skopeo
+    yq
+commands =
+    # pack rock and export to docker
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval ".platforms | keys | .[0]" rockcraft.yaml) && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
+             DOCKER_IMAGE=$NAME:$VERSION && \
+             echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
+             skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+
+[testenv:sanity]
+passenv = *
+deps =
+    pytest
+    charmed-kubeflow-chisme
+commands =
+    # run rock tests
+    pytest -s -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
+
+[testenv:integration]
+passenv = *
+allowlist_externals =
+    echo
+commands =
+    # TODO: Implement integration tests here
+    echo "WARNING: This is a placeholder test - no test is implemented here."


### PR DESCRIPTION
### Description
---
* Add rockcraft.yaml
* Add tests
* Add tox.ini

This is re-open request for #92 .

Logs from tests
---
`juju status` after all tests are passed:
```
Model     Controller          Cloud/Region        Version  SLA          Timestamp
kubeflow  microk8s-localhost  microk8s/localhost  3.6.1    unsupported  09:54:41+02:00

App                      Version                Status   Scale  Charm                    Channel          Rev  Address         Exposed  Message
grafana-agent-k8s        0.40.4                 blocked      1  grafana-agent-k8s        latest/stable     80  10.152.183.195  no       Missing ['grafana-cloud-config']|['logging-consumer'] for logging-provider; ['grafana-cloud-config']|['send-remote-wr...
istio-ingressgateway                            active       1  istio-gateway            1.16/stable     1005  10.152.183.88   no       
istio-pilot                                     active       1  istio-pilot              1.16/stable      662  10.152.183.138  no       
knative-operator                                active       1  knative-operator         latest/edge      542  10.152.183.55   no       
knative-serving                                 active       1  knative-serving          latest/edge      572  10.152.183.61   no       
kserve-controller                               blocked      1  kserve-controller                           0  10.152.183.92   no       Cannot parse a config-defined images list from config '{' - thisconfig input will be ignored.
metacontroller-operator                         active       1  metacontroller-operator  latest/edge      401  10.152.183.56   no       
minio                    res:oci-image@1755999  active       1  minio                    ckf-1.7/stable   214  10.152.183.225  no       
resource-dispatcher                             active       1  resource-dispatcher      latest/edge      236  10.152.183.90   no       

Unit                        Workload  Agent  Address       Ports          Message
grafana-agent-k8s/0*        blocked   idle   10.1.142.145                 Missing ['grafana-cloud-config']|['logging-consumer'] for logging-provider; ['grafana-cloud-config']|['send-remote-wr...
istio-ingressgateway/0*     active    idle   10.1.142.186                 
istio-pilot/0*              active    idle   10.1.142.174                 
knative-operator/0*         active    idle   10.1.142.189                 
knative-serving/0*          active    idle   10.1.142.136                 
kserve-controller/0*        blocked   idle   10.1.142.179                 Cannot parse a config-defined images list from config '{' - thisconfig input will be ignored.
metacontroller-operator/0*  active    idle   10.1.142.134                 
minio/0*                    active    idle   10.1.142.178  9000-9001/TCP  
resource-dispatcher/0*      active    idle   10.1.142.139                 
```

Logs of passed integration tests `tox -vve integration -- --model kubeflow --keep-models` (only last included due to PR message maximum length):
```
---------------------------------------------------------------------------------------------- live log teardown -----------------------------------------------------------------------------------------------
INFO     pytest_operator.plugin:plugin.py:903 Model status:

Model     Controller          Cloud/Region        Version  SLA          Timestamp
kubeflow  microk8s-localhost  microk8s/localhost  3.6.1    unsupported  09:45:54+02:00

App                      Version                Status   Scale  Charm                    Channel          Rev  Address         Exposed  Message
grafana-agent-k8s        0.40.4                 blocked      1  grafana-agent-k8s        latest/stable     80  10.152.183.195  no       Missing ['grafana-cloud-config']|['logging-consumer'] for logging-provider; ['grafana-cloud-config']|['send-remote-wr...
istio-ingressgateway                            active       1  istio-gateway            1.16/stable     1005  10.152.183.88   no       
istio-pilot                                     active       1  istio-pilot              1.16/stable      662  10.152.183.138  no       
knative-operator                                active       1  knative-operator         latest/edge      542  10.152.183.55   no       
knative-serving                                 active       1  knative-serving          latest/edge      572  10.152.183.61   no       
kserve-controller                               blocked      1  kserve-controller                           0  10.152.183.92   no       Cannot parse a config-defined images list from config '{' - thisconfig input will be ignored.
metacontroller-operator                         active       1  metacontroller-operator  latest/edge      401  10.152.183.56   no       
minio                    res:oci-image@1755999  active       1  minio                    ckf-1.7/stable   214  10.152.183.225  no       
resource-dispatcher                             active       1  resource-dispatcher      latest/edge      236  10.152.183.90   no       

Unit                        Workload  Agent  Address       Ports          Message
grafana-agent-k8s/0*        blocked   idle   10.1.142.145                 Missing ['grafana-cloud-config']|['logging-consumer'] for logging-provider; ['grafana-cloud-config']|['send-remote-wr...
istio-ingressgateway/0*     active    idle   10.1.142.186                 
istio-pilot/0*              active    idle   10.1.142.174                 
knative-operator/0*         active    idle   10.1.142.189                 
knative-serving/0*          active    idle   10.1.142.136                 
kserve-controller/0*        blocked   idle   10.1.142.179                 Cannot parse a config-defined images list from config '{' - thisconfig input will be ignored.
metacontroller-operator/0*  active    idle   10.1.142.134                 
minio/0*                    active    idle   10.1.142.178  9000-9001/TCP  
resource-dispatcher/0*      active    idle   10.1.142.139                 

INFO     pytest_operator.plugin:plugin.py:909 Juju error logs:

unit-kserve-controller-0: 09:28:31 ERROR unit.kserve-controller/0.juju-log Failed to handle <InstallEvent via KServeControllerCharm/on/install[1]> with error: Please relate to istio-pilot:gateway-info
unit-kserve-controller-0: 09:40:44 ERROR unit.kserve-controller/0.juju-log object-storage:6: Failed to handle <RelationChangedEvent via KServeControllerCharm/on/object_storage_relation_changed[151]> with error: Waiting for object-storage relation data
unit-kserve-controller-0: 09:45:37 ERROR unit.kserve-controller/0.juju-log Failed to handle <ConfigChangedEvent via KServeControllerCharm/on/config_changed[206]> with error: Cannot parse a config-defined images list from config '{' - thisconfig input will be ignored.

INFO     pytest_operator.plugin:plugin.py:991 Forgetting model main...
INFO     httpx:_client.py:1038 HTTP Request: DELETE https://127.0.0.1:16443/api/v1/namespaces/test-namespace-resource-dispatcher "HTTP/1.1 200 OK"


======================================================================================= 18 passed in 1284.53s (0:21:24) ========================================================================================
integration: 1305623 I exit 0 (1285.63 seconds) /home/yurchenko/kserve-operators/charms/kserve-controller> pytest -v --tb native --ignore=/home/yurchenko/kserve-operators/charms/kserve-controller/tests/unit --log-cli-level=INFO -s --model kubeflow --keep-models pid=2919676 [tox/execute/api.py:286]
  integration: OK (1305.43=setup[19.80]+cmd[1285.63] seconds)
  congratulations :) (1305.50 seconds)
```