### PR TITLE
Added `huggingfaceserver` rock and tests

### DIFF
--- a/huggingfaceserver/dummy_pyproject.toml
+++ b/huggingfaceserver/dummy_pyproject.toml
@@ -1,0 +1,11 @@
+[tool.poetry]
+name = "workaround-for-editable-install"
+version = "0.0.1"
+description = ""
+authors = ["none"]
+
+[tool.poetry.dependencies]
+# This range should match that used upstream: https://github.com/kserve/kserve/blob/v0.13.0/python/huggingfaceserver/pyproject.toml#L13
+python = ">=3.9,<3.12"
+kserve = { path = "../python/kserve", develop = false }
+huggingfaceserver = { path = "../python/huggingfaceserver", develop = false }

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -59,7 +59,6 @@ parts:
     stage-packages:
       - cuda-12-1    
     build-packages:
-      - cuda-12-1
       - build-essential
       - libgomp1
     build-environment:

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -24,9 +24,19 @@ services:
       SAFETENSORS_FAST_GPU: "1"
       HF_HUB_DISABLE_TELEMETRY: "1"
       CUDA: "12.1"
+      CUDA_VERSION: "12.1.0"
+      NVIDIA_VISIBLE_DEVICES: "all"
+      NVIDIA_DRIVER_CAPABILITIES: "compute,utility"
       PATH: "/usr/local/nvidia/bin:/usr/local/cuda/bin:$PATH"
       LD_LIBRARY_PATH: "/usr/local/cuda-12.1/lib:/usr/local/cuda-12.1/lib64:$LD_LIBRARY_PATH"    
 entrypoint-service: huggingfaceserver
+
+package-repositories:
+  - type: apt
+    formats: [deb]
+    path: /
+    key-id: AE09FE4BBD223A84B2CCFCE3F60F4B3D7FA2AF80
+    url: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/
 
 parts:
   security-team-requirement:
@@ -51,21 +61,11 @@ parts:
     - python3.10  
     # Including python3-pip here means pip also gets primed for the final rock
     - python3-pip
+    - cuda-12.1
     override-build: |
       # Populate the build system's python environment with all packages needed for 
       # the server in the final rock
 
-      # Install cuda-12-1
-      curl -sL "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub" | apt-key add -
-      echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/ /" > /etc/apt/sources.list.d/cuda.list
-      apt-get -yq update
-      
-      apt-get install -yq --no-install-recommends \
-        cuda-${CUDA}
-
-      apt-get clean
-      rm -rf /var/lib/apt/lists/*
-      
       # Setup poetry
       pip install poetry==1.7.1 vllm==0.4.2
       poetry config virtualenvs.create false 

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -67,7 +67,7 @@ parts:
 
       # Copy cuda libs
       mkdir -p $CRAFT_PART_INSTALL/usr/local
-      cp -a /usr/local/cuda-12-1 $CRAFT_PART_INSTALL/usr/local/
+      cp -a /usr/local/cuda-12.1 $CRAFT_PART_INSTALL/usr/local/
     
       # Copy dpkg and apt information to the final image
       mkdir -p $CRAFT_PART_INSTALL/var/lib/dpkg

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -52,17 +52,17 @@ parts:
     source: https://github.com/kserve/kserve.git
     source-subdir: python
     source-tag: v0.13.0
+    overlay-packages:
+      - python3.10  
+      # Including python3-pip here means pip also gets primed for the final rock
+      - python3-pip
+      - cuda-12-1
     build-packages:
       - build-essential
       - libgomp1
     build-environment:
       - CUDA: "12.1"
       - LD_LIBRARY_PATH: "/usr/local/cuda-12.1/lib:/usr/local/cuda-12.1/lib64:$LD_LIBRARY_PATH"          
-    overlay-packages:
-    - python3.10  
-    # Including python3-pip here means pip also gets primed for the final rock
-    - python3-pip
-    - cuda-12.1
     override-build: |
       # Populate the build system's python environment with all packages needed for 
       # the server in the final rock

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -35,7 +35,7 @@ package-repositories:
   - type: apt
     formats: [deb]
     path: /
-    key-id: D42D0685F3B6EA3A1A577E8FE9DFDC80A6D6E0C6
+    key-server: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub
     url: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/
 
 parts:

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -63,7 +63,7 @@ parts:
       apt-get -yq update
     
       # Install CUDA toolkit
-      apt-get -yq install --no-install-recommends cuda-compat-12-1 cuda-cudart-12-1 cuda-toolkit-12-1-config-common cuda-toolkit-12-config-common cuda-toolkit-config-common
+      apt-get -yq install --no-install-recommends cuda-keyring cuda-compat-12-1 cuda-cudart-12-1 cuda-toolkit-12-1-config-common cuda-toolkit-12-config-common cuda-toolkit-config-common 
 
       # Copy cuda libs
       mkdir -p $CRAFT_PART_INSTALL/usr/local

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -36,7 +36,7 @@ package-repositories:
     formats: [deb]
     path: /
     key-id: EB693B3035CD5710E231E123A4B469963BF863CC
-    url: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/
+    url: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64
 
 parts:
   security-team-requirement:
@@ -56,7 +56,7 @@ parts:
       - python3.10  
       # Including python3-pip here means pip also gets primed for the final rock
       - python3-pip
-      - cuda-12.1
+      - cuda-12-1
     build-packages:
       - build-essential
       - libgomp1

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -63,7 +63,7 @@ parts:
       apt-get -yq update
     
       # Install CUDA toolkit
-      apt-get -yq install --no-install-recommends cuda-runtime-12-1
+      apt-get -yq install --no-install-recommends cuda-keyring cuda-runtime-12-1 cuda-compat-12-1 
 
       # Copy cuda libs
       mkdir -p $CRAFT_PART_INSTALL/usr/local

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -61,7 +61,7 @@ parts:
       apt-get -yq update
       
       apt-get install -yq --no-install-recommends \
-        cuda-runtime-${CUDA}
+        cuda-${CUDA}
 
       apt-get clean
       rm -rf /var/lib/apt/lists/*

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -46,12 +46,13 @@ parts:
     - python3.10  
     # Including python3-pip here means pip also gets primed for the final rock
     - python3-pip
+    - cuda-12-1
     override-build: |
       # Populate the build system's python environment with all packages needed for 
       # the server in the final rock
       
       # Setup poetry
-      pip install poetry==1.7.1
+      pip install poetry==1.7.1 vllm==0.4.2
       poetry config virtualenvs.create false 
 
       # Install the kserve package, this specific server package, and their dependencies.

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -62,7 +62,7 @@ parts:
     - python3.10  
     # Including python3-pip here means pip also gets primed for the final rock
     - python3-pip
-    - cuda-12-1
+    - cuda-12.1
     override-build: |
       # Populate the build system's python environment with all packages needed for 
       # the server in the final rock

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -31,12 +31,12 @@ services:
       LD_LIBRARY_PATH: "/usr/local/cuda-12.1/lib:/usr/local/cuda-12.1/lib64:$LD_LIBRARY_PATH"    
 entrypoint-service: huggingfaceserver
 
-#package-repositories:
-#  - type: apt
-#    formats: [deb]
-#    path: /
-#    key-id: EB693B3035CD5710E231E123A4B469963BF863CC
-#    url: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64
+package-repositories:
+  - type: apt
+    formats: [deb]
+    path: /
+    key-id: EB693B3035CD5710E231E123A4B469963BF863CC
+    url: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64
 
 parts:
   security-team-requirement:
@@ -56,8 +56,11 @@ parts:
       - python3.10  
       # Including python3-pip here means pip also gets primed for the final rock
       - python3-pip
-    #stage-packages:
-    #  - cuda-runtime-12-1    
+    stage-packages:
+      - cuda-runtime-12-1
+      - cuda-compat-12-1
+      - cuda-cudart-12-1
+      - cuda-toolkit-12-1
     build-packages:
       - build-essential
       - libgomp1
@@ -68,13 +71,6 @@ parts:
     override-build: |
       # Populate the build system's python environment with all packages needed for 
       # the server in the final rock
-
-      curl -sL "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub" | apt-key add -
-      echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/ /" > /etc/apt/sources.list.d/cuda.list
-      apt-get -yq update
-      apt-get -yq install --no-install-recommends cuda-compat-12-1 cuda-cudart-12-1 cuda-toolkit-12-1
-      apt-get clean
-      rm -rf /var/lib/apt/lists/*
       
       # Setup poetry
       pip install --no-cache-dir poetry==1.7.1 vllm==0.4.2

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -57,7 +57,7 @@ parts:
       # Including python3-pip here means pip also gets primed for the final rock
       - python3-pip
     stage-packages:
-      - cuda-runtime-12-1    
+      - cuda-12-1    
     build-packages:
       - build-essential
       - libgomp1

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -57,13 +57,13 @@ parts:
       # Including python3-pip here means pip also gets primed for the final rock
       - python3-pip
     stage-packages:
-      - cuda-12-1    
+      - cuda-runtime-12-1    
     build-packages:
       - build-essential
       - libgomp1
     build-environment:
       - CUDA: "12.1"
-      - LD_LIBRARY_PATH: "/usr/local/cuda-12.1/lib:/usr/local/cuda-12.1/lib64:$LD_LIBRARY_PATH"          
+      - LD_LIBRARY_PATH: "/usr/local/cuda-12.1/lib:/usr/local/cuda-12.1/lib64:$LD_LIBRARY_PATH"
     override-build: |
       # Populate the build system's python environment with all packages needed for 
       # the server in the final rock
@@ -90,7 +90,11 @@ parts:
       ln -s /usr/bin/python3.10 $CRAFT_PART_INSTALL/usr/bin/python
 
       rm -rf /root/.cache
- 
+      
+    override-stage: |
+      dpkg -l
+      craftclt default
+
   # Copy licenses
   third-party:
     plugin: nil

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -56,6 +56,7 @@ parts:
       - python3.10  
       # Including python3-pip here means pip also gets primed for the final rock
       - python3-pip
+    stage-packages:
       - cuda-runtime-12-1    
     build-packages:
       - build-essential

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -25,7 +25,7 @@ services:
       HF_HUB_DISABLE_TELEMETRY: "1"
       CUDA: "12.1"
       PATH: "/usr/local/nvidia/bin:/usr/local/cuda/bin:$PATH"
-      LD_LIBRARY_PATH: "/usr/local/cuda/lib:/usr/local/cuda/lib64"    
+      LD_LIBRARY_PATH: "/usr/local/cuda-12.1/lib:/usr/local/cuda-12.1/lib64:$LD_LIBRARY_PATH"    
 entrypoint-service: huggingfaceserver
 
 parts:
@@ -61,7 +61,7 @@ parts:
       apt-get -yq update
       
       apt-get install -yq --no-install-recommends \
-        cuda-${CUDA}
+        cuda-runtime-${CUDA}
 
       apt-get clean
       rm -rf /var/lib/apt/lists/*

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -57,7 +57,7 @@ parts:
       # Including python3-pip here means pip also gets primed for the final rock
       - python3-pip
     stage-packages:
-      - cuda-toolkit-12-1
+      - cuda-runtime-12-1    
     build-packages:
       - build-essential
       - libgomp1
@@ -67,6 +67,9 @@ parts:
     override-build: |
       # Populate the build system's python environment with all packages needed for 
       # the server in the final rock
+
+      wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/uda-keyring_1.1-1_all.deb
+      sudo dpkg -i cuda-keyring_1.1-1_all.deb
 
       # Setup poetry
       pip install --no-cache-dir poetry==1.7.1 vllm==0.4.2

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -54,7 +54,7 @@ parts:
       curl -sL "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub" | apt-key add -
       echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/ /" > /etc/apt/sources.list.d/cuda.list
       apt-get -yq update
-      apt-get -yq install --no-install-recommends cuda-compat-cuda-compat-12-1 cuda-cudart-cuda-cudart-12-1 cuda-toolkit-12-1
+      apt-get -yq install --no-install-recommends cuda-compat-12-1 cuda-cudart-12-1 cuda-toolkit-12-1
       apt-get clean
       rm -rf /var/lib/apt/lists/*
       

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -61,6 +61,7 @@ parts:
     build-packages:
       - build-essential
       - libgomp1
+      - wget
     build-environment:
       - CUDA: "12.1"
       - LD_LIBRARY_PATH: "/usr/local/cuda-12.1/lib:/usr/local/cuda-12.1/lib64:$LD_LIBRARY_PATH"
@@ -68,8 +69,11 @@ parts:
       # Populate the build system's python environment with all packages needed for 
       # the server in the final rock
 
-      wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/uda-keyring_1.1-1_all.deb
-      sudo dpkg -i cuda-keyring_1.1-1_all.deb
+      wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
+      dpkg -i cuda-keyring_1.1-1_all.deb
+
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/local/deb-packages
+      cp cuda-keyring_1.1-1_all.deb ${CRAFT_PART_INSTALL}/usr/local/deb-packages/
 
       # Setup poetry
       pip install --no-cache-dir poetry==1.7.1 vllm==0.4.2

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -73,7 +73,7 @@ parts:
       mkdir -p $CRAFT_PART_INSTALL/var/lib/dpkg
       cp -a /var/lib/dpkg/* $CRAFT_PART_INSTALL/var/lib/dpkg/
 
-      mkdir -p $CRAFT_PART_INSTALL/var/lib/apt
+      mkdir -p $CRAFT_PART_INSTALL/var/lib/apt/lists
       cp -a /var/lib/apt/lists/* $CRAFT_PART_INSTALL/var/lib/apt/lists/
     
       mkdir -p $CRAFT_PART_INSTALL/etc/apt

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -31,12 +31,12 @@ services:
       LD_LIBRARY_PATH: "/usr/local/cuda-12.1/lib:/usr/local/cuda-12.1/lib64:$LD_LIBRARY_PATH"    
 entrypoint-service: huggingfaceserver
 
-package-repositories:
-  - type: apt
-    formats: [deb]
-    path: /
-    key-id: EB693B3035CD5710E231E123A4B469963BF863CC
-    url: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64
+#package-repositories:
+#  - type: apt
+#    formats: [deb]
+#    path: /
+#    key-id: EB693B3035CD5710E231E123A4B469963BF863CC
+#    url: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64
 
 parts:
   security-team-requirement:
@@ -56,8 +56,8 @@ parts:
       - python3.10  
       # Including python3-pip here means pip also gets primed for the final rock
       - python3-pip
-    stage-packages:
-      - cuda-runtime-12-1    
+    #stage-packages:
+    #  - cuda-runtime-12-1    
     build-packages:
       - build-essential
       - libgomp1
@@ -71,6 +71,7 @@ parts:
 
       wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
       dpkg -i cuda-keyring_1.1-1_all.deb
+      apt-get install cuda-runtime-12-1
 
       mkdir -p ${CRAFT_PART_INSTALL}/usr/local/deb-packages
       cp cuda-keyring_1.1-1_all.deb ${CRAFT_PART_INSTALL}/usr/local/deb-packages/

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -56,8 +56,8 @@ parts:
       - python3.10  
       # Including python3-pip here means pip also gets primed for the final rock
       - python3-pip
-      - cuda-12-1
     build-packages:
+      - cuda-12-1
       - build-essential
       - libgomp1
     build-environment:

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -57,6 +57,7 @@ parts:
       - libgomp1
     build-environment:
       - CUDA: "12.1"
+      - LD_LIBRARY_PATH: "/usr/local/cuda-12.1/lib:/usr/local/cuda-12.1/lib64:$LD_LIBRARY_PATH"          
     overlay-packages:
     - python3.10  
     # Including python3-pip here means pip also gets primed for the final rock

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -47,17 +47,6 @@ parts:
       dpkg-query --root=${CRAFT_PROJECT_DIR}/../bundles/ubuntu-22.04/rootfs/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
       > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
 
-  cuda:
-    plugin: nil
-    override-prime: |
-      craftctl default    
-      curl -sL "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub" | apt-key add -
-      echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/ /" > /etc/apt/sources.list.d/cuda.list
-      apt-get -yq update
-      apt-get -yq install --no-install-recommends cuda-compat-12-1 cuda-cudart-12-1 cuda-toolkit-12-1
-      apt-get clean
-      rm -rf /var/lib/apt/lists/*
-      
   python:
     plugin: nil
     source: https://github.com/kserve/kserve.git
@@ -100,6 +89,13 @@ parts:
       # a symbolic link
       mkdir -p $CRAFT_PART_INSTALL/usr/bin/
       ln -s /usr/bin/python3.10 $CRAFT_PART_INSTALL/usr/bin/python
+
+      curl -sL "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub" | apt-key add -
+      echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/ /" > /etc/apt/sources.list.d/cuda.list
+      apt-get -yq update
+      apt-get -yq install --no-install-recommends cuda-compat-12-1 cuda-cudart-12-1 cuda-toolkit-12-1
+      apt-get clean
+      rm -rf /var/lib/apt/lists/*
 
       rm -rf /root/.cache
 

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -47,6 +47,15 @@ parts:
       dpkg-query --root=${CRAFT_PROJECT_DIR}/../bundles/ubuntu-22.04/rootfs/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
       > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
 
+  cuda:
+    plugin: nil
+    override-prime: |
+      craftctl default    
+      wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
+      dpkg -i cuda-keyring_1.1-1_all.deb
+      apt-get update -y
+      apt-get install cuda-runtime-12-1 -y
+      
   python:
     plugin: nil
     source: https://github.com/kserve/kserve.git
@@ -68,11 +77,6 @@ parts:
     override-build: |
       # Populate the build system's python environment with all packages needed for 
       # the server in the final rock
-
-      wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
-      dpkg -i cuda-keyring_1.1-1_all.deb
-      apt-get update -y
-      apt-get install cuda-runtime-12-1 -y
 
       mkdir -p ${CRAFT_PART_INSTALL}/usr/local/deb-packages
       cp cuda-keyring_1.1-1_all.deb ${CRAFT_PART_INSTALL}/usr/local/deb-packages/

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -35,8 +35,7 @@ package-repositories:
   - type: apt
     formats: [deb]
     path: /
-    key-server: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/
-    key-id: 3bf863cc
+    key-id: mQINBGJYmlEBEAC6nJmeqByeReM+MSy4palACCnfOg4pOxffrrkldxz4jrDOZNK4
     url: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/
 
 parts:

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -56,8 +56,8 @@ parts:
       - python3.10  
       # Including python3-pip here means pip also gets primed for the final rock
       - python3-pip
-    build-packages:
       - cuda-12-1
+    build-packages:
       - build-essential
       - libgomp1
     build-environment:
@@ -87,8 +87,6 @@ parts:
       # a symbolic link
       mkdir -p $CRAFT_PART_INSTALL/usr/bin/
       ln -s /usr/bin/python3.10 $CRAFT_PART_INSTALL/usr/bin/python
-    stage:
-      - -usr/local/cuda-12.1/*
 
   # Copy licenses
   third-party:

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -56,7 +56,6 @@ parts:
       - python3.10  
       # Including python3-pip here means pip also gets primed for the final rock
       - python3-pip
-    stage-packages:
       - cuda-runtime-12-1    
     build-packages:
       - build-essential
@@ -90,10 +89,6 @@ parts:
       ln -s /usr/bin/python3.10 $CRAFT_PART_INSTALL/usr/bin/python
 
       rm -rf /root/.cache
-      
-    override-stage: |
-      dpkg -l
-      craftclt default
 
   # Copy licenses
   third-party:

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -56,7 +56,7 @@ parts:
       - python3.10  
       # Including python3-pip here means pip also gets primed for the final rock
       - python3-pip
-      - cuda-12-1
+      - cuda-12.1
     build-packages:
       - build-essential
       - libgomp1

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -9,13 +9,6 @@ version: "0.13.0"
 license: Apache-2.0
 base: ubuntu@22.04
 run-user: _daemon_
-environment: 
-  HF_HOME: "/tmp/huggingface"
-  SAFETENSORS_FAST_GPU: "1"
-  HF_HUB_DISABLE_TELEMETRY: "1"
-  CUDA: "12.1"
-  PATH: "/usr/local/nvidia/bin:/usr/local/cuda/bin:$PATH"
-  LD_LIBRARY_PATH: "/usr/local/cuda/lib:/usr/local/cuda/lib64"
   
 platforms:
     amd64:
@@ -26,6 +19,13 @@ services:
     summary: "Huggingface server service"
     startup: enabled
     command: "python -m huggingfaceserver [ ]"
+    environment: 
+      HF_HOME: "/tmp/huggingface"
+      SAFETENSORS_FAST_GPU: "1"
+      HF_HUB_DISABLE_TELEMETRY: "1"
+      CUDA: "12.1"
+      PATH: "/usr/local/nvidia/bin:/usr/local/cuda/bin:$PATH"
+      LD_LIBRARY_PATH: "/usr/local/cuda/lib:/usr/local/cuda/lib64"    
 entrypoint-service: huggingfaceserver
 
 parts:

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -35,7 +35,8 @@ package-repositories:
   - type: apt
     formats: [deb]
     path: /
-    key-server: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub
+    key-server: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/
+    key-id: 3bf863cc
     url: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/
 
 parts:

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -57,16 +57,31 @@ parts:
       - CUDA: "12.1"
       - LD_LIBRARY_PATH: "/usr/local/cuda-12.1/lib:/usr/local/cuda-12.1/lib64:$LD_LIBRARY_PATH"
     override-build: |
-      # Populate the build system's python environment with all packages needed for 
-      # the server in the final rock
-
+      # Add NVIDIA repository key and update the package list
       curl -sL "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub" | apt-key add -
       echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/ /" > /etc/apt/sources.list.d/cuda.list
       apt-get -yq update
+    
+      # Install CUDA toolkit
       apt-get -yq install --no-install-recommends cuda-toolkit-12-1
+
+      # Copy cuda libs
+      cp - a /usr/local/cuda-12-1 $CRAFT_PART_INSTALL/usr/local/cuda-12-1
+    
+      # Copy dpkg and apt information to the final image
+      mkdir -p $CRAFT_PART_INSTALL/var/lib/dpkg
+      cp -a /var/lib/dpkg/* $CRAFT_PART_INSTALL/var/lib/dpkg/
+
+      mkdir -p $CRAFT_PART_INSTALL/var/lib/apt
+      cp -a /var/lib/apt/lists/* $CRAFT_PART_INSTALL/var/lib/apt/lists/
+    
+      mkdir -p $CRAFT_PART_INSTALL/etc/apt
+      cp -a /etc/apt/sources.list.d $CRAFT_PART_INSTALL/etc/apt/
+      cp -a /etc/apt/trusted.gpg* $CRAFT_PART_INSTALL/etc/apt/
+    
+      # Clean up the apt cache
       apt-get clean
       rm -rf /var/lib/apt/lists/*
-      exit 1
       
       # Setup poetry
       pip install --no-cache-dir poetry==1.7.1 vllm==0.4.2

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -59,11 +59,11 @@ parts:
     override-build: |
       # Add NVIDIA repository key and update the package list
       wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
-      dpkg -i cuda-keyring_1.1-1_all.deb
+      dpkg -i cuda-keyring_1.0-1_all.deb
       apt-get -yq update
     
       # Install CUDA toolkit
-      apt-get -yq install --no-install-recommends cuda-keyring cuda-compat-12-1 cuda-cudart-12-1 cuda-toolkit-12-1-config-common cuda-toolkit-12-config-common cuda-toolkit-config-common 
+      apt-get -yq install --no-install-recommends cuda-keyring=1.0-1 cuda-compat-12-1=530.30.02-1 cuda-cudart-12-1=12.1.55-1 cuda-toolkit-12-1-config-common=12.1.105-1 cuda-toolkit-12-config-common=12.3.52-1 cuda-toolkit-config-common=12.3.52-1 
 
       # Copy cuda libs
       mkdir -p $CRAFT_PART_INSTALL/usr/local

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -35,7 +35,7 @@ package-repositories:
   - type: apt
     formats: [deb]
     path: /
-    key-id: mQINBGJYmlEBEAC6nJmeqByeReM+MSy4palACCnfOg4pOxffrrkldxz4jrDOZNK4
+    key-id: EB693B3035CD5710E231E123A4B469963BF863CC
     url: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/
 
 parts:

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -13,6 +13,9 @@ environment:
   HF_HOME: "/tmp/huggingface"
   SAFETENSORS_FAST_GPU: "1"
   HF_HUB_DISABLE_TELEMETRY: "1"
+  CUDA: "12.1"
+  PATH: "/usr/local/nvidia/bin:/usr/local/cuda/bin:$PATH"
+  LD_LIBRARY_PATH: "/usr/local/cuda/lib:/usr/local/cuda/lib64"
   
 platforms:
     amd64:
@@ -42,14 +45,26 @@ parts:
     build-packages:
       - build-essential
       - libgomp1
+    build-environment:
+      - CUDA: "12.1"
     overlay-packages:
     - python3.10  
     # Including python3-pip here means pip also gets primed for the final rock
     - python3-pip
-    - cuda-12-1
     override-build: |
       # Populate the build system's python environment with all packages needed for 
       # the server in the final rock
+
+      # Install cuda-12-1
+      curl -sL "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub" | apt-key add -
+      echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/ /" > /etc/apt/sources.list.d/cuda.list
+      apt-get -yq update
+      
+      apt-get install -yq --no-install-recommends \
+        cuda-${CUDA}
+
+      apt-get clean
+      rm -rf /var/lib/apt/lists/*
       
       # Setup poetry
       pip install poetry==1.7.1 vllm==0.4.2

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -58,7 +58,7 @@ parts:
       - LD_LIBRARY_PATH: "/usr/local/cuda-12.1/lib:/usr/local/cuda-12.1/lib64:$LD_LIBRARY_PATH"
     override-build: |
       # Add NVIDIA repository key and update the package list
-      wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
+      wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.0-1_all.deb
       dpkg -i cuda-keyring_1.0-1_all.deb
       apt-get -yq update
     

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -57,7 +57,7 @@ parts:
       # Including python3-pip here means pip also gets primed for the final rock
       - python3-pip
     stage-packages:
-      - cuda-runtime-12-1    
+      - cuda-toolkit-12-1
     build-packages:
       - build-essential
       - libgomp1

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -58,8 +58,8 @@ parts:
       - LD_LIBRARY_PATH: "/usr/local/cuda-12.1/lib:/usr/local/cuda-12.1/lib64:$LD_LIBRARY_PATH"
     override-build: |
       # Add NVIDIA repository key and update the package list
-      curl -sL "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub" | apt-key add -
-      echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/ /" > /etc/apt/sources.list.d/cuda.list
+      wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
+      dpkg -i cuda-keyring_1.1-1_all.deb
       apt-get -yq update
     
       # Install CUDA toolkit

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -61,7 +61,7 @@ parts:
     - python3.10  
     # Including python3-pip here means pip also gets primed for the final rock
     - python3-pip
-    - cuda-12.1
+    - cuda-12-1
     override-build: |
       # Populate the build system's python environment with all packages needed for 
       # the server in the final rock
@@ -86,6 +86,8 @@ parts:
       # a symbolic link
       mkdir -p $CRAFT_PART_INSTALL/usr/bin/
       ln -s /usr/bin/python3.10 $CRAFT_PART_INSTALL/usr/bin/python
+    stage:
+      - -usr/local/cuda-12.1/*
 
   # Copy licenses
   third-party:

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -31,13 +31,6 @@ services:
       LD_LIBRARY_PATH: "/usr/local/cuda-12.1/lib:/usr/local/cuda-12.1/lib64:$LD_LIBRARY_PATH"    
 entrypoint-service: huggingfaceserver
 
-package-repositories:
-  - type: apt
-    formats: [deb]
-    path: /
-    key-id: EB693B3035CD5710E231E123A4B469963BF863CC
-    url: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64
-
 parts:
   security-team-requirement:
     plugin: nil
@@ -56,11 +49,6 @@ parts:
       - python3.10  
       # Including python3-pip here means pip also gets primed for the final rock
       - python3-pip
-    stage-packages:
-      - cuda-runtime-12-1
-      - cuda-compat-12-1
-      - cuda-cudart-12-1
-      - cuda-toolkit-12-1
     build-packages:
       - build-essential
       - libgomp1
@@ -71,6 +59,13 @@ parts:
     override-build: |
       # Populate the build system's python environment with all packages needed for 
       # the server in the final rock
+
+      curl -sL "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub" | apt-key add -
+      echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/ /" > /etc/apt/sources.list.d/cuda.list
+      apt-get -yq update
+      apt-get -yq install --no-install-recommends cuda-toolkit-12-1
+      apt-get clean
+      rm -rf /var/lib/apt/lists/*
       
       # Setup poetry
       pip install --no-cache-dir poetry==1.7.1 vllm==0.4.2

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -35,7 +35,7 @@ package-repositories:
   - type: apt
     formats: [deb]
     path: /
-    key-id: AE09FE4BBD223A84B2CCFCE3F60F4B3D7FA2AF80
+    key-id: D42D0685F3B6EA3A1A577E8FE9DFDC80A6D6E0C6
     url: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/
 
 parts:

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -19,7 +19,8 @@ services:
     summary: "Huggingface server service"
     startup: enabled
     command: "python -m huggingfaceserver [ ]"
-    environment: 
+    environment:
+      PYTHONPATH: "/usr/local/lib/python3.10/dist-packages"
       HF_HOME: "/tmp/huggingface"
       SAFETENSORS_FAST_GPU: "1"
       HF_HUB_DISABLE_TELEMETRY: "1"

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -57,7 +57,7 @@ parts:
       # Including python3-pip here means pip also gets primed for the final rock
       - python3-pip
     stage-packages:
-      - cuda-12-1    
+      - cuda-runtime-12-1    
     build-packages:
       - build-essential
       - libgomp1

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -50,11 +50,11 @@ parts:
   cuda:
     plugin: nil
     override-prime: |
-      craftctl default    
       wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
       dpkg -i cuda-keyring_1.1-1_all.deb
       apt-get update -y
       apt-get install cuda-runtime-12-1 -y
+      craftctl default    
       
   python:
     plugin: nil

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -56,8 +56,10 @@ parts:
       - python3.10  
       # Including python3-pip here means pip also gets primed for the final rock
       - python3-pip
-      - cuda-12-1
+    stage-packages:
+      - cuda-12-1    
     build-packages:
+      - cuda-12-1
       - build-essential
       - libgomp1
     build-environment:
@@ -87,7 +89,7 @@ parts:
       # a symbolic link
       mkdir -p $CRAFT_PART_INSTALL/usr/bin/
       ln -s /usr/bin/python3.10 $CRAFT_PART_INSTALL/usr/bin/python
-
+ 
   # Copy licenses
   third-party:
     plugin: nil

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -77,10 +77,7 @@ parts:
     override-build: |
       # Populate the build system's python environment with all packages needed for 
       # the server in the final rock
-
-      mkdir -p ${CRAFT_PART_INSTALL}/usr/local/deb-packages
-      cp cuda-keyring_1.1-1_all.deb ${CRAFT_PART_INSTALL}/usr/local/deb-packages/
-
+      
       # Setup poetry
       pip install --no-cache-dir poetry==1.7.1 vllm==0.4.2
       poetry config virtualenvs.create false 

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -63,7 +63,7 @@ parts:
       apt-get -yq update
     
       # Install CUDA toolkit
-      apt-get -yq install --no-install-recommends cuda-toolkit-12-1
+      apt-get -yq install --no-install-recommends cuda-runtime-12-1
 
       # Copy cuda libs
       mkdir -p $CRAFT_PART_INSTALL/usr/local

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -1,0 +1,82 @@
+# Based on https://github.com/kserve/kserve/blob/v0.13.0/python/huggingface_server.Dockerfile
+# See ../CONTRIBUTING.md for more details about the patterns used in this rock.
+# This rock is implemented with some atypical patterns due to the native of the upstream
+# Dockerfile.
+name: huggingfaceserver
+summary: Huggingface server for Kserve deployments
+description: "Kserve Huggingface server"
+version: "0.13.0"
+license: Apache-2.0
+base: ubuntu@22.04
+run-user: _daemon_
+environment: 
+  HF_HOME: "/tmp/huggingface"
+  SAFETENSORS_FAST_GPU: "1"
+  HF_HUB_DISABLE_TELEMETRY: "1"
+  
+platforms:
+    amd64:
+
+services:
+  huggingfaceserver:
+    override: replace
+    summary: "Huggingface server service"
+    startup: enabled
+    command: "python -m huggingfaceserver [ ]"
+entrypoint-service: huggingfaceserver
+
+parts:
+  security-team-requirement:
+    plugin: nil
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+      dpkg-query --root=${CRAFT_PROJECT_DIR}/../bundles/ubuntu-22.04/rootfs/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
+      > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
+
+  python:
+    plugin: nil
+    source: https://github.com/kserve/kserve.git
+    source-subdir: python
+    source-tag: v0.13.0
+    build-packages:
+      - build-essential
+      - libgomp1
+    overlay-packages:
+    - python3.10  
+    # Including python3-pip here means pip also gets primed for the final rock
+    - python3-pip
+    override-build: |
+      # Populate the build system's python environment with all packages needed for 
+      # the server in the final rock
+      
+      # Setup poetry
+      pip install poetry==1.7.1
+      poetry config virtualenvs.create false 
+
+      # Install the kserve package, this specific server package, and their dependencies.
+      mkdir -p ./python_env_builddir
+      cp -rf $CRAFT_PROJECT_DIR/dummy_pyproject.toml ./python_env_builddir/pyproject.toml
+      (cd python_env_builddir && poetry install --no-interaction --no-root)
+
+      # Promote the packages we've installed from the local env to the primed image
+      mkdir -p $CRAFT_PART_INSTALL/usr/local/lib/python3.10/dist-packages
+      cp -fr /usr/local/lib/python3.10/dist-packages/* $CRAFT_PART_INSTALL/usr/local/lib/python3.10/dist-packages/
+
+      mkdir -p $CRAFT_PART_INSTALL/usr/local/share
+      cp -fr /usr/local/share/* $CRAFT_PART_INSTALL/usr/local/share/
+
+      # Ensure `python` is an executable command in our primed image by making
+      # a symbolic link
+      mkdir -p $CRAFT_PART_INSTALL/usr/bin/
+      ln -s /usr/bin/python3.10 $CRAFT_PART_INSTALL/usr/bin/python
+
+  # Copy licenses
+  third-party:
+    plugin: nil
+    after: [python]
+    source: https://github.com/kserve/kserve.git
+    source-subdir: python
+    source-tag: v0.13.0
+    override-build: |
+      cp -fr third_party/* ${CRAFT_PART_INSTALL}/third_party

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -63,7 +63,7 @@ parts:
       apt-get -yq update
     
       # Install CUDA toolkit
-      apt-get -yq install --no-install-recommends cuda-keyring cuda-runtime-12-1 cuda-compat-12-1 
+      apt-get -yq install --no-install-recommends cuda-runtime-12-1 cuda-compat-12-1 
 
       # Copy cuda libs
       mkdir -p $CRAFT_PART_INSTALL/usr/local

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -68,6 +68,13 @@ parts:
     override-build: |
       # Populate the build system's python environment with all packages needed for 
       # the server in the final rock
+
+      curl -sL "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub" | apt-key add -
+      echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/ /" > /etc/apt/sources.list.d/cuda.list
+      apt-get -yq update
+      apt-get -yq install --no-install-recommends cuda-compat-12-1 cuda-cudart-12-1 cuda-toolkit-12-1
+      apt-get clean
+      rm -rf /var/lib/apt/lists/*
       
       # Setup poetry
       pip install --no-cache-dir poetry==1.7.1 vllm==0.4.2
@@ -89,14 +96,7 @@ parts:
       # a symbolic link
       mkdir -p $CRAFT_PART_INSTALL/usr/bin/
       ln -s /usr/bin/python3.10 $CRAFT_PART_INSTALL/usr/bin/python
-
-      curl -sL "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub" | apt-key add -
-      echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/ /" > /etc/apt/sources.list.d/cuda.list
-      apt-get -yq update
-      apt-get -yq install --no-install-recommends cuda-compat-12-1 cuda-cudart-12-1 cuda-toolkit-12-1
-      apt-get clean
-      rm -rf /var/lib/apt/lists/*
-
+      
       rm -rf /root/.cache
 
   # Copy licenses

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -71,7 +71,8 @@ parts:
 
       wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
       dpkg -i cuda-keyring_1.1-1_all.deb
-      apt-get install cuda-runtime-12-1
+      apt-get update -y
+      apt-get install cuda-runtime-12-1 -y
 
       mkdir -p ${CRAFT_PART_INSTALL}/usr/local/deb-packages
       cp cuda-keyring_1.1-1_all.deb ${CRAFT_PART_INSTALL}/usr/local/deb-packages/

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -59,13 +59,6 @@ parts:
     override-build: |
       # Populate the build system's python environment with all packages needed for 
       # the server in the final rock
-
-      curl -sL "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub" | apt-key add -
-      echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/ /" > /etc/apt/sources.list.d/cuda.list
-      apt-get -yq update
-      apt-get -yq install --no-install-recommends cuda-toolkit-12-1
-      apt-get clean
-      rm -rf /var/lib/apt/lists/*
       
       # Setup poetry
       pip install --no-cache-dir poetry==1.7.1 vllm==0.4.2
@@ -89,6 +82,16 @@ parts:
       ln -s /usr/bin/python3.10 $CRAFT_PART_INSTALL/usr/bin/python
       
       rm -rf /root/.cache
+      
+    override-prime: |
+      craftctl default
+      curl -sL "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub" | apt-key add -
+      echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/ /" > /etc/apt/sources.list.d/cuda.list
+      apt-get -yq update
+      apt-get -yq install --no-install-recommends cuda-toolkit-12-1
+      apt-get clean
+      rm -rf /var/lib/apt/lists/*
+    
 
   # Copy licenses
   third-party:

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -66,7 +66,8 @@ parts:
       apt-get -yq install --no-install-recommends cuda-toolkit-12-1
 
       # Copy cuda libs
-      cp - a /usr/local/cuda-12-1 $CRAFT_PART_INSTALL/usr/local/cuda-12-1
+      mkdir -p $CRAFT_PART_INSTALL/usr/local
+      cp -a /usr/local/cuda-12-1 $CRAFT_PART_INSTALL/usr/local/
     
       # Copy dpkg and apt information to the final image
       mkdir -p $CRAFT_PART_INSTALL/var/lib/dpkg

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -50,11 +50,13 @@ parts:
   cuda:
     plugin: nil
     override-prime: |
-      wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
-      dpkg -i cuda-keyring_1.1-1_all.deb
-      apt-get update -y
-      apt-get install cuda-runtime-12-1 -y
       craftctl default    
+      curl -sL "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub" | apt-key add -
+      echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/ /" > /etc/apt/sources.list.d/cuda.list
+      apt-get -yq update
+      apt-get -yq install --no-install-recommends cuda-compat-cuda-compat-12-1 cuda-cudart-cuda-cudart-12-1 cuda-toolkit-12-1
+      apt-get clean
+      rm -rf /var/lib/apt/lists/*
       
   python:
     plugin: nil

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -69,7 +69,7 @@ parts:
       # the server in the final rock
 
       # Setup poetry
-      pip install poetry==1.7.1 vllm==0.4.2
+      pip install --no-cache-dir poetry==1.7.1 vllm==0.4.2
       poetry config virtualenvs.create false 
 
       # Install the kserve package, this specific server package, and their dependencies.
@@ -88,6 +88,8 @@ parts:
       # a symbolic link
       mkdir -p $CRAFT_PART_INSTALL/usr/bin/
       ln -s /usr/bin/python3.10 $CRAFT_PART_INSTALL/usr/bin/python
+
+      rm -rf /root/.cache
  
   # Copy licenses
   third-party:

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -59,6 +59,14 @@ parts:
     override-build: |
       # Populate the build system's python environment with all packages needed for 
       # the server in the final rock
+
+      curl -sL "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub" | apt-key add -
+      echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/ /" > /etc/apt/sources.list.d/cuda.list
+      apt-get -yq update
+      apt-get -yq install --no-install-recommends cuda-toolkit-12-1
+      apt-get clean
+      rm -rf /var/lib/apt/lists/*
+      exit 1
       
       # Setup poetry
       pip install --no-cache-dir poetry==1.7.1 vllm==0.4.2
@@ -82,15 +90,6 @@ parts:
       ln -s /usr/bin/python3.10 $CRAFT_PART_INSTALL/usr/bin/python
       
       rm -rf /root/.cache
-      
-    override-prime: |
-      craftctl default
-      curl -sL "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub" | apt-key add -
-      echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/ /" > /etc/apt/sources.list.d/cuda.list
-      apt-get -yq update
-      apt-get -yq install --no-install-recommends cuda-toolkit-12-1
-      apt-get clean
-      rm -rf /var/lib/apt/lists/*
     
 
   # Copy licenses

--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -63,7 +63,7 @@ parts:
       apt-get -yq update
     
       # Install CUDA toolkit
-      apt-get -yq install --no-install-recommends cuda-runtime-12-1 cuda-compat-12-1 
+      apt-get -yq install --no-install-recommends cuda-compat-12-1 cuda-cudart-12-1 cuda-toolkit-12-1-config-common cuda-toolkit-12-config-common cuda-toolkit-config-common
 
       # Copy cuda libs
       mkdir -p $CRAFT_PART_INSTALL/usr/local

--- a/huggingfaceserver/tests/test_rock.py
+++ b/huggingfaceserver/tests/test_rock.py
@@ -12,7 +12,6 @@ from charmed_kubeflow_chisme.rock import CheckRock
 @pytest.mark.abort_on_fail
 def test_rock():
     """Test rock."""
-    temp_dir, container_name = rock_test_env
     check_rock = CheckRock("rockcraft.yaml")
     rock_image = check_rock.get_name()
     rock_version = check_rock.get_version()

--- a/huggingfaceserver/tests/test_rock.py
+++ b/huggingfaceserver/tests/test_rock.py
@@ -1,0 +1,57 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import random
+import pytest
+import string
+import subprocess
+
+from charmed_kubeflow_chisme.rock import CheckRock
+
+
+@pytest.mark.abort_on_fail
+def test_rock(rock_test_env):
+    """Test rock."""
+    temp_dir, container_name = rock_test_env
+    check_rock = CheckRock("rockcraft.yaml")
+    rock_image = check_rock.get_name()
+    rock_version = check_rock.get_version()
+    LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
+
+    # assert we have the expected files
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /usr/local/lib/python3.10/dist-packages/huggingfaceserver",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /usr/local/lib/python3.10/dist-packages/kserve",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /third_party",
+        ],
+        check=True,
+    )

--- a/huggingfaceserver/tests/test_rock.py
+++ b/huggingfaceserver/tests/test_rock.py
@@ -10,7 +10,7 @@ from charmed_kubeflow_chisme.rock import CheckRock
 
 
 @pytest.mark.abort_on_fail
-def test_rock(rock_test_env):
+def test_rock():
     """Test rock."""
     temp_dir, container_name = rock_test_env
     check_rock = CheckRock("rockcraft.yaml")

--- a/huggingfaceserver/tox.ini
+++ b/huggingfaceserver/tox.ini
@@ -1,0 +1,54 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+[tox]
+skipsdist = True
+skip_missing_interpreters = True
+envlist = pack, export-to-docker, sanity, integration
+
+[testenv]
+setenv =
+    PYTHONPATH={toxinidir}
+    PYTHONBREAKPOINT=ipdb.set_trace
+    CHARM_REPO=https://github.com/canonical/kserve-operators.git
+    CHARM_BRANCH=main
+    LOCAL_CHARM_DIR=charm_repo
+
+[testenv:pack]
+passenv = *
+allowlist_externals =
+    rockcraft
+commands =
+    rockcraft pack
+
+[testenv:export-to-docker]
+passenv = *
+allowlist_externals =
+    bash
+    skopeo
+    yq
+commands =
+    # pack rock and export to docker
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval ".platforms | keys | .[0]" rockcraft.yaml) && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
+             DOCKER_IMAGE=$NAME:$VERSION && \
+             echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
+             skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+
+[testenv:sanity]
+passenv = *
+deps =
+    pytest
+    charmed-kubeflow-chisme
+commands =
+    # run rock tests
+    pytest -s -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
+
+[testenv:integration]
+passenv = *
+allowlist_externals =
+    echo
+commands =
+    # TODO: Implement integration tests here
+    echo "WARNING: This is a placeholder test - no test is implemented here."


### PR DESCRIPTION
### Description
---
* Add rockcraft.yaml
* Add tests
* Add tox.ini

This is re-open request for #91.

Logs from tests
---
`juju status` after all tests are passed:
```
Model     Controller          Cloud/Region        Version  SLA          Timestamp
kubeflow  microk8s-localhost  microk8s/localhost  3.6.1    unsupported  00:59:28Z

App                      Version                Status   Scale  Charm                    Channel          Rev  Address         Exposed  Message
grafana-agent-k8s        0.40.4                 blocked      1  grafana-agent-k8s        latest/stable     80  10.152.183.167  no       Missing ['grafana-cloud-config']|['logging-consumer'] for logging-provider; ['grafana-cloud-config']|['send-remote-wr...
istio-ingressgateway                            active       1  istio-gateway            1.16/stable     1005  10.152.183.244  no       
istio-pilot                                     active       1  istio-pilot              1.16/stable      662  10.152.183.243  no       
knative-operator                                active       1  knative-operator         latest/edge      542  10.152.183.230  no       
knative-serving                                 active       1  knative-serving          latest/edge      572  10.152.183.100  no       
kserve-controller                               blocked      1  kserve-controller                           0  10.152.183.123  no       Cannot parse a config-defined images list from config '{' - thisconfig input will be ignored.
metacontroller-operator                         active       1  metacontroller-operator  latest/edge      401  10.152.183.89   no       
minio                    res:oci-image@1755999  active       1  minio                    ckf-1.7/stable   214  10.152.183.68   no       
resource-dispatcher                             active       1  resource-dispatcher      latest/edge      236  10.152.183.181  no       

Unit                        Workload  Agent  Address      Ports          Message
grafana-agent-k8s/0*        blocked   idle   10.1.172.40                 Missing ['grafana-cloud-config']|['logging-consumer'] for logging-provider; ['grafana-cloud-config']|['send-remote-wr...
istio-ingressgateway/0*     active    idle   10.1.172.35                 
istio-pilot/0*              active    idle   10.1.172.34                 
knative-operator/0*         active    idle   10.1.172.46                 
knative-serving/0*          active    idle   10.1.172.47                 
kserve-controller/0*        blocked   idle   10.1.172.38                 Cannot parse a config-defined images list from config '{' - thisconfig input will be ignored.
metacontroller-operator/0*  active    idle   10.1.172.60                 
minio/0*                    active    idle   10.1.172.59  9000-9001/TCP  
resource-dispatcher/0*      active    idle   10.1.172.62                 
```

Logs of passed integration tests `tox -vve integration -- --model kubeflow --keep-models` (only last included due to PR message maximum length):
```
---------------------------------------------------------------------------------------------- live log teardown -----------------------------------------------------------------------------------------------
INFO     pytest_operator.plugin:plugin.py:903 Model status:

Model     Controller          Cloud/Region        Version  SLA          Timestamp
kubeflow  microk8s-localhost  microk8s/localhost  3.6.1    unsupported  00:51:28Z

App                      Version                Status   Scale  Charm                    Channel          Rev  Address         Exposed  Message
grafana-agent-k8s        0.40.4                 blocked      1  grafana-agent-k8s        latest/stable     80  10.152.183.167  no       Missing ['grafana-cloud-config']|['logging-consumer'] for logging-provider; ['grafana-cloud-config']|['send-remote-wr...
istio-ingressgateway                            active       1  istio-gateway            1.16/stable     1005  10.152.183.244  no       
istio-pilot                                     active       1  istio-pilot              1.16/stable      662  10.152.183.243  no       
knative-operator                                active       1  knative-operator         latest/edge      542  10.152.183.230  no       
knative-serving                                 active       1  knative-serving          latest/edge      572  10.152.183.100  no       
kserve-controller                               blocked      1  kserve-controller                           0  10.152.183.123  no       Cannot parse a config-defined images list from config '{' - thisconfig input will be ignored.
metacontroller-operator                         active       1  metacontroller-operator  latest/edge      401  10.152.183.89   no       
minio                    res:oci-image@1755999  active       1  minio                    ckf-1.7/stable   214  10.152.183.68   no       
resource-dispatcher                             active       1  resource-dispatcher      latest/edge      236  10.152.183.181  no       

Unit                        Workload  Agent  Address      Ports          Message
grafana-agent-k8s/0*        blocked   idle   10.1.172.40                 Missing ['grafana-cloud-config']|['logging-consumer'] for logging-provider; ['grafana-cloud-config']|['send-remote-wr...
istio-ingressgateway/0*     active    idle   10.1.172.35                 
istio-pilot/0*              active    idle   10.1.172.34                 
knative-operator/0*         active    idle   10.1.172.46                 
knative-serving/0*          active    idle   10.1.172.47                 
kserve-controller/0*        blocked   idle   10.1.172.38                 Cannot parse a config-defined images list from config '{' - thisconfig input will be ignored.
metacontroller-operator/0*  active    idle   10.1.172.60                 
minio/0*                    active    idle   10.1.172.59  9000-9001/TCP  
resource-dispatcher/0*      active    idle   10.1.172.62                 

INFO     pytest_operator.plugin:plugin.py:909 Juju error logs:

unit-kserve-controller-0: 00:32:03 ERROR unit.kserve-controller/0.juju-log Failed to handle <InstallEvent via KServeControllerCharm/on/install[1]> with error: Please relate to istio-pilot:gateway-info
unit-kserve-controller-0: 00:46:30 ERROR unit.kserve-controller/0.juju-log object-storage:6: Failed to handle <RelationChangedEvent via KServeControllerCharm/on/object_storage_relation_changed[151]> with error: Waiting for object-storage relation data
unit-kserve-controller-0: 00:51:08 ERROR unit.kserve-controller/0.juju-log Failed to handle <ConfigChangedEvent via KServeControllerCharm/on/config_changed[206]> with error: Cannot parse a config-defined images list from config '{' - thisconfig input will be ignored.

INFO     pytest_operator.plugin:plugin.py:991 Forgetting model main...
INFO     httpx:_client.py:1038 HTTP Request: DELETE https://127.0.0.1:16443/api/v1/namespaces/test-namespace-resource-dispatcher "HTTP/1.1 200 OK"


======================================================================================= 18 passed in 2862.29s (0:47:42) ========================================================================================
integration: 2864218 I exit 0 (2863.82 seconds) /home/ubuntu/kserve-operators/charms/kserve-controller> pytest -v --tb native --ignore=/home/ubuntu/kserve-operators/charms/kserve-controller/tests/unit --log-cli-level=INFO -s --model kubeflow --keep-models pid=237295 [tox/execute/api.py:286]
  integration: OK (2863.91=setup[0.09]+cmd[2863.82] seconds)
  congratulations :) (2864.02 seconds)
```
