### PR TITLE
Add `tensorflow-serving` rock and tests

### DIFF
--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -75,12 +75,6 @@ parts:
       - TF_SERVING_BUILD_OPTIONS: "--config=release"
     stage-packages:
       - ca-certificates
-    stage-environment:
-      - CUDA_LIB: "11-2"
-      - CUDA: "11.2"
-      - OLD_CUDA: "11.1"
-      - TF_TENSORRT_VERSION: "7.2.2"
-      - CUDNN_VERSION: "8.1.0.77"      
     override-build: |
       set -xe
 

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -281,7 +281,7 @@ parts:
 
     override-prime: |
       # copy all artifacts
-      cp -r ${CRAFT_STAGE}/usr/bin/tf_serving_entrypoint.sh /usr/bin/tf_serving_entrypoint.sh
+      cp -r ${CRAFT_PART_INSTALL}/usr/bin/tf_serving_entrypoint.sh /usr/bin/tf_serving_entrypoint.sh
 
       chmod +x /usr/bin/tf_serving_entrypoint.sh
 

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -104,7 +104,7 @@ parts:
         libcudnn8-dev=${CUDNN_VERSION}-1+cuda${CUDA} \
         libcurl3-dev \
         libzmq3-dev \
-        cuda-11-2
+        cuda-${CUDA_LIB}
 
       apt-get clean
       rm -rf /var/lib/apt/lists/*
@@ -157,9 +157,7 @@ parts:
       update-alternatives --install /usr/bin/python python /usr/bin/python3.6 0
       
       curl -fSsL -O "https://bootstrap.pypa.io/pip/3.6/get-pip.py"
-
       python3 get-pip.py
-
       rm -f get-pip.py
 
       pip3 --no-cache-dir install \
@@ -196,8 +194,8 @@ parts:
       ln -s /usr/lib/x86_64-linux-gnu/libcudnn.so /usr/local/cuda-${CUDA}/lib64/libcudnn.so
       ln -s /usr/lib/x86_64-linux-gnu/libcudnn.so.${TF_CUDNN_VERSION} /usr/local/cuda-${CUDA}/lib64/libcudnn.so.${TF_CUDNN_VERSION}
 
+      # Build tensorflow_model_server
       export TF_NCCL_VERSION=
-
       export TF_SERVING_BAZEL_OPTIONS=""
 
       ln -s /usr/local/cuda-${CUDA}/lib64/stubs/libcuda.so /usr/local/cuda-${CUDA}/lib64/stubs/libcuda.so.1
@@ -210,26 +208,6 @@ parts:
       tensorflow_serving/model_servers:tensorflow_model_server
 
       cp bazel-bin/tensorflow_serving/model_servers/tensorflow_model_server ${CRAFT_PART_INSTALL}/usr/bin/
-
-      rm -f /usr/local/cuda/lib64/stubs/libcuda.so.1
-
-      # Patch for deprecated python tensorflow-gpu package
-      sed -i '49,52d' tensorflow_serving/tools/pip_package/setup.py
-
-      bazel build --color=yes --curses=yes \
-      ${TF_SERVING_BAZEL_OPTIONS} \
-      --verbose_failures \
-      --output_filter=DONT_MATCH_ANYTHING \
-      ${TF_SERVING_BUILD_OPTIONS} \
-      tensorflow_serving/tools/pip_package:build_pip_package && \
-      bazel-bin/tensorflow_serving/tools/pip_package/build_pip_package \
-      /tmp/pip
-
-      mkdir -p ${CRAFT_PART_INSTALL}/models/model
-      
-      pip --no-cache-dir install --upgrade /tmp/pip/tensorflow_serving_api_gpu-*.whl
-      
-      rm -rf /tmp/pip
 
       # Clean build
       bazel clean --expunge --color=yes

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -153,6 +153,8 @@ parts:
       
       apt-get clean
       rm -rf /var/lib/apt/lists/*
+
+      # --- CUDA install END ---
       
       python3.6 -m pip install pip --upgrade      
 
@@ -194,10 +196,10 @@ parts:
       rm -f /bazel/bazel-$BAZEL_VERSION-installer-linux-x86_64.sh
 
       # Fix paths so that CUDNN can be found: https://github.com/tensorflow/tensorflow/issues/8264
-      mkdir ${CRAFT_PART_INSTALL}/usr/lib/x86_64-linux-gnu/include/
-      ln -s /usr/include/cudnn.h ${CRAFT_PART_INSTALL}/usr/local/cuda/include/cudnn.h
-      ln -s /usr/lib/x86_64-linux-gnu/libcudnn.so ${CRAFT_PART_INSTALL}/usr/local/cuda/lib64/libcudnn.so
-      ln -s /usr/lib/x86_64-linux-gnu/libcudnn.so.${TF_CUDNN_VERSION} ${CRAFT_PART_INSTALL}/usr/local/cuda/lib64/libcudnn.so.${TF_CUDNN_VERSION}
+      mkdir /usr/lib/x86_64-linux-gnu/include/
+      ln -s /usr/include/cudnn.h /usr/local/cuda-${CUDA}/include/cudnn.h
+      ln -s /usr/lib/x86_64-linux-gnu/libcudnn.so /usr/local/cuda-${CUDA}/lib64/libcudnn.so
+      ln -s /usr/lib/x86_64-linux-gnu/libcudnn.so.${TF_CUDNN_VERSION} /usr/local/cuda-${CUDA}/lib64/libcudnn.so.${TF_CUDNN_VERSION}
 
       export TF_NCCL_VERSION=
 
@@ -205,8 +207,8 @@ parts:
 
       export TF_SERVING_BAZEL_OPTIONS=""
 
-      ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1
-      export LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:${LD_LIBRARY_PATH}
+      ln -s /usr/local/cuda-${CUDA}/lib64/stubs/libcuda.so /usr/local/cuda-${CUDA}/lib64/stubs/libcuda.so.1
+      export LD_LIBRARY_PATH=/usr/local/cuda-${CUDA}/lib64/stubs:${LD_LIBRARY_PATH}
 
       bazel build --color=yes --curses=yes --config=cuda --copt="-fPIC"\
       ${TF_SERVING_BAZEL_OPTIONS} \

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -225,6 +225,9 @@ parts:
 
       rm /usr/local/cuda/lib64/stubs/libcuda.so.1
 
+      # Patch for deprecated python tensorflow-gpu package
+      sed -i '49,52d' tensorflow_serving/tools/pip_package/setup.py
+
       bazel build --color=yes --curses=yes \
       ${TF_SERVING_BAZEL_OPTIONS} \
       --verbose_failures \

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -21,7 +21,7 @@ services:
        TF_TENSORRT_VERSION: "7.2.2"
        CUDNN_VERSION: "8.1.0.77"
        LD_LIBRARY_PATH: "/usr/local/nvidia/lib:/usr/local/nvidia/lib64"
-    command: "/usr/bin/tf_serving_entrypoint.sh [ ]"
+    command: "tensorflow_model_server --port=8500 --rest_api_port=8501 --model_name=${MODEL_NAME} --model_base_path=${MODEL_BASE_PATH}/${MODEL_NAME} [ ]"
 
 parts:
   security-team-requirement:
@@ -239,14 +239,6 @@ parts:
       /tmp/pip
 
       mkdir -p ${CRAFT_PART_INSTALL}/models
-
-      echo '#!/bin/bash \n\n\
-      tensorflow_model_server --port=8500 --rest_api_port=8501 \
-      --model_name=${MODEL_NAME} --model_base_path=${MODEL_BASE_PATH}/${MODEL_NAME} \
-      "$@"' > ${CRAFT_PART_INSTALL}/usr/bin/tf_serving_entrypoint.sh
-
-      chmod +x ${CRAFT_PART_INSTALL}/usr/bin/tf_serving_entrypoint.sh
-
       
       pip --no-cache-dir install --upgrade /tmp/pip/tensorflow_serving_api_gpu-*.whl
       

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -281,7 +281,7 @@ parts:
 
     override-prime: |
       # copy all artifacts
-      cp -r ${CRAFT_PART_INSTALL}/usr/bin/tf_serving_entrypoint.sh /usr/bin/tf_serving_entrypoint.sh
+      cp ${CRAFT_PART_INSTALL}/usr/bin/tf_serving_entrypoint.sh /usr/bin/tf_serving_entrypoint.sh	
 
       chmod +x /usr/bin/tf_serving_entrypoint.sh
 

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -15,11 +15,11 @@ services:
     environment:
        NVIDIA_VISIBLE_DEVICES: all
        NVIDIA_DRIVER_CAPABILITIES: "compute,utility"
-       MODEL_BASE_PATH=/models
-       MODEL_NAME=model
-       CUDA=11.2
-       TF_TENSORRT_VERSION=7.2.2
-       CUDNN_VERSION=8.1.0.77
+       MODEL_BASE_PATH: "/models"
+       MODEL_NAME: "model"
+       CUDA: "11.2"
+       TF_TENSORRT_VERSION: "7.2.2"
+       CUDNN_VERSION: "8.1.0.77"
        LD_LIBRARY_PATH: "/usr/local/nvidia/lib:/usr/local/nvidia/lib64"
     command: "/usr/bin/tf_serving_entrypoint.sh [ ]"
 

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -1,4 +1,6 @@
-# Based on https://github.com/tensorflow/serving/blob/master/tensorflow_serving/tools/docker/Dockerfile.gpu
+# Based on the following Dockerfiles:
+# https://github.com/tensorflow/serving/blob/2.6.2/tensorflow_serving/tools/docker/Dockerfile.gpu
+# https://github.com/tensorflow/serving/blob/2.6.2/tensorflow_serving/tools/docker/Dockerfile.devel-gpu
 name: tensorflow-serving
 summary: TensorFlow model server
 description: TensorFlow Serving is a flexible, high-performance serving system for machine learning models, designed for production environments.

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -204,13 +204,10 @@ parts:
 
       export TF_NCCL_VERSION=
 
-      cd ./tensorflow_serving
-
       export TF_SERVING_BAZEL_OPTIONS=""
 
       ln -s /usr/local/cuda-${CUDA}/lib64/stubs/libcuda.so /usr/local/cuda-${CUDA}/lib64/stubs/libcuda.so.1
       
-      LD_LIBRARY_PATH=/usr/local/cuda-${CUDA}/lib64/stubs:${LD_LIBRARY_PATH} \
       bazel build --color=yes --curses=yes --config=cuda --copt="-fPIC" \
       ${TF_SERVING_BAZEL_OPTIONS} \
       --verbose_failures \

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -3,7 +3,7 @@ summary: TensorFlow model server
 description: Test
 version: v2.6.2
 license: Apache-2.0
-base: ubuntu@22.04
+base: ubuntu@20.04
 run-user: _daemon_
 services:
   serving:
@@ -27,8 +27,8 @@ parts:
       (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
       dpkg-query -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
       > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
-
-  serving:
+      
+  cuda-build:
     plugin: nil
     source: https://github.com/tensorflow/serving
     source-type: git
@@ -37,25 +37,8 @@ parts:
       - automake
       - build-essential
       - ca-certificates
-      - cuda-command-line-tools-11-2
-      - libcublas-11-2 
-      - libcublas-dev-11-2 
-      - cuda-nvrtc-11-2 
-      - cuda-nvrtc-dev-11-2 
-      - cuda-nvprune-11-2 
-      - cuda-cudart-dev-11-2 
-      - libcufft-dev-11-2 
-      - libcurand-dev-11-2 
-      - libcusolver-dev-11-2 
-      - libcusparse-dev-11-2 
       - curl 
       - git 
-      - libfreetype6-dev 
-      - libtool 
-      - libcudnn8=8.1.0.77-1+cuda11.2
-      - libcudnn8-dev=8.1.0.77-1+cuda11.2
-      - libcurl3-dev 
-      - libzmq3-dev 
       - mlocate 
       - openjdk-8-jdk
       - openjdk-8-jre-headless 
@@ -69,14 +52,13 @@ parts:
       - zlib1g-dev 
       - python3-distutils 
       - python-distutils-extra
-      - python3.6
-      - python3.6-dev
       - python3-pip
-      - python3.6-venv
     build-environment:
       - CUDNN_VERSION: "8.1.0.77"
       - TF_TENSORRT_VERSION: "7.2.2"
       - CUDA: "11.2"
+      - OLD_CUDA: "11.1"      
+      - CUDA_LIB: "11-2"
       - LD_LIBRARY_PATH: "/usr/local/cuda/extras/CUPTI/lib64:/usr/local/cuda/lib64:/usr/local/cuda/lib64/stubs:/usr/include/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH"
       - BAZEL_VERSION: 3.7.2
       - CI_BUILD_PYTHON: python
@@ -87,26 +69,91 @@ parts:
       - TF_CUDNN_VERSION: "8"
       - TMP: /tmp
       - TF_SERVING_BUILD_OPTIONS: "--config=release"
-
     override-build: |
       set -xe
+
+      curl -sL "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub" | apt-key add -
+      echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /" > /etc/apt/sources.list.d/cuda.list
+      apt-get -yq update
+      
+      apt-get install -yq --no-install-recommends \
+        cuda-command-line-tools-${CUDA_LIB} \
+        libcublas-${CUDA_LIB} \
+        libcublas-dev-${CUDA_LIB} \
+        cuda-nvrtc-${CUDA_LIB} \
+        cuda-nvrtc-dev-${CUDA_LIB} \
+        cuda-nvprune-${CUDA_LIB} \
+        cuda-cudart-dev-${CUDA_LIB} \
+        libcufft-dev-${CUDA_LIB} \
+        libcurand-dev-${CUDA_LIB} \
+        libcusolver-dev-${CUDA_LIB} \
+        libcusparse-dev-${CUDA_LIB} \
+        libfreetype6-dev \
+        libtool \
+        libcudnn8=8.1.0.77-1+cuda${CUDA} \
+        libcudnn8-dev=8.1.0.77-1+cuda${CUDA} \
+        libcurl3-dev \
+        libzmq3-dev
+
+      apt-get clean
+      rm -rf /var/lib/apt/lists/*
+
+      # Install python3.6
+      echo "deb http://ppa.launchpad.net/deadsnakes/ppa/ubuntu $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/deadsnakes-ubuntu-ppa.list
+
+      apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F23C5A6CF475977595C89F51BA6932366A755776
+
+      apt-get update
+      apt-get install -yq python3.6 python3.6-dev python3.6-venv
+
+      apt-get clean
+      rm -rf /var/lib/apt/lists/*
+
+      # create Nvidia/CUDA directories
+      mkdir -p "${CRAFT_PART_INSTALL}/usr/local" "${CRAFT_PART_INSTALL}/usr/local/bin"
+
+      # copy CUDA directories
+      cp -rp /usr/local/cuda-${CUDA} ${CRAFT_PART_INSTALL}/usr/local
+      ln -sf /usr/local/cuda-${CUDA} ${CRAFT_PART_INSTALL}/usr/local/cuda
+
+      # tensorflow fix - wrong libcuda lib path (+ reconfigure dynamic linker run-time bindings)
+      # ln -s /usr/local/cuda/lib64/stubs/libcuda.so ${CRAFT_PART_INSTALL}/usr/local/cuda/lib64/stubs/libcuda.so.1
+      # echo "/usr/local/cuda/lib64/stubs" > /etc/ld.so.conf.d/z-cuda-stubs.conf
+      # ldconfig
+
+      # copy CUDA config
+      # mkdir -p ${CRAFT_PART_INSTALL}/etc/ld.so.conf.d/
+      # cp -r /etc/ld.so.conf.d/z-cuda-stubs.conf ${CRAFT_PART_INSTALL}/etc/ld.so.conf.d/z-cuda-stubs.conf
+
+      # tensorflow fix - wrong libcusolver lib path
+      # https://github.com/tensorflow/tensorflow/issues/43947#issuecomment-748273679
+      # ln -s /usr/local/cuda-${CUDA}/targets/x86_64-linux/lib/libcusolver.so.11 ${CRAFT_PART_INSTALL}/usr/local/cuda-${CUDA}/targets/x86_64-linux/lib/libcusolver.so.10
+
+      # tensorflow fix - some tensorflow tools expect a `python` binary
+      # ln -s /usr/local/bin/python3 ${CRAFT_PART_INSTALL}/usr/local/bin/python
 
       find /usr/local/cuda-11.2/lib64/ -type f -name 'lib*_static.a' -not -name 'libcudart_static.a' -delete
       rm /usr/lib/x86_64-linux-gnu/libcudnn_static_v8.a
 
-      apt-get update && \
+      # install - other nvidia stuff
+      curl -sL "https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu2004/x86_64/7fa2af80.pub" | apt-key add -
+      echo "deb https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu2004/x86_64 /" > /etc/apt/sources.list.d/nvidia-ml.list
+      echo "deb https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64 /" > /etc/apt/sources.list.d/nvidia-ml.list
+      apt-get -yq update
+
       apt-get install -y --no-install-recommends libnvinfer7=${TF_TENSORRT_VERSION}-1+cuda11.1 \
-      libnvinfer-dev=${TF_TENSORRT_VERSION}-1+cuda11.1 \
-      libnvinfer-plugin-dev=${TF_TENSORRT_VERSION}-1+cuda11.1 \
-      libnvinfer-plugin7=${TF_TENSORRT_VERSION}-1+cuda11.1 \
-      libnvonnxparsers7=${TF_TENSORRT_VERSION}-1+cuda11.1 \
-      libnvparsers7=${TF_TENSORRT_VERSION}-1+cuda11.1\
-      libnvonnxparsers-dev=${TF_TENSORRT_VERSION}-1+cuda11.1 \
-      libnvparsers-dev=${TF_TENSORRT_VERSION}-1+cuda11.1
+      libnvinfer-dev=${TF_TENSORRT_VERSION}-1+cuda${OLD_CUDA} \
+      libnvinfer-plugin-dev=${TF_TENSORRT_VERSION}-1+cuda${OLD_CUDA} \
+      libnvinfer-plugin7=${TF_TENSORRT_VERSION}-1+cuda${OLD_CUDA} \
+      libnvonnxparsers7=${TF_TENSORRT_VERSION}-1+cuda${OLD_CUDA} \
+      libnvparsers7=${TF_TENSORRT_VERSION}-1+cuda${OLD_CUDA}\
+      libnvonnxparsers-dev=${TF_TENSORRT_VERSION}-1+cuda${OLD_CUDA} \
+      libnvparsers-dev=${TF_TENSORRT_VERSION}-1+cuda${OLD_CUDA}
+      
       apt-get clean
       rm -rf /var/lib/apt/lists/*
-
-      python3.6 -m pip install pip --upgrade
+      
+      python3.6 -m pip install pip --upgrade      
 
       update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6
       update-alternatives --install /usr/bin/python python /usr/bin/python3.6
@@ -176,9 +223,4 @@ parts:
       # Clean build
       bazel clean --expunge --color=yes
       rm -rf /root/.cache      
-      
-    override-stage: |
-      mkdir -p $CRAFT_PART_INSTALL/usr/bin/
-      exit 1
-      
-    
+

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -89,6 +89,8 @@ parts:
       - TF_SERVING_BUILD_OPTIONS: "--config=release"
 
     override-build:
+      set -xe
+      
       find /usr/local/cuda-11.2/lib64/ -type f -name 'lib*_static.a' -not -name 'libcudart_static.a' -delete
       rm /usr/lib/x86_64-linux-gnu/libcudnn_static_v8.a
 
@@ -130,14 +132,14 @@ parts:
       mkdir /bazel
 
       cd bazel
-
+      
       curl -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36" -fSsL -O https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh
-
-      curl -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36" -fSsL -o /bazel/LICENSE.txt https://raw.githubusercontent.com/bazelbuild/bazel/master/LICENSE
+      
+      curl -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36" -fSsL -o /LICENSE.txt https://raw.githubusercontent.com/bazelbuild/bazel/master/LICENSE
 
       chmod +x bazel-*.sh
 
-      ./bazel-$BAZEL_VERSION-installer-linux-x86_64.sh
+      ./bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh
 
       cd ..
 

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -75,6 +75,7 @@ parts:
       - TF_SERVING_BUILD_OPTIONS: "--config=release"
     stage-packages:
       - ca-certificates
+      - curl      
     override-build: |
       set -xe
 

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -203,7 +203,7 @@ parts:
 
       export TF_NCCL_VERSION=
 
-      cd /tensorflow_serving
+      cd ./tensorflow_serving
 
       export TF_SERVING_BAZEL_OPTIONS=""
 

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -1,0 +1,189 @@
+name: tensorflow-serving
+summary: TensorFlow model server
+description: |
+None
+version: v2.6.2
+license: Apache-2.0
+base: ubuntu:22.04
+run-user: _daemon_
+services:
+  serving:
+    override: replace
+    summary: "tensorflow model server"
+    startup: enabled
+    environment:
+       NVIDIA_VISIBLE_DEVICES: all
+       NVIDIA_DRIVER_CAPABILITIES: compute,utility
+       LD_LIBRARY_PATH: /usr/local/nvidia/lib:/usr/local/nvidia/lib64
+    command: nil
+platforms:
+  amd64:
+
+
+parts:
+  security-team-requirement:
+    plugin: nil
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+      dpkg-query -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
+      > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
+
+  serving:
+    plugin: nil
+    source: https://github.com/tensorflow/serving
+    source-type: git
+    source-tag: 2.6.2
+    build-packages:
+      - automake
+      - build-essential
+      - ca-certificates
+      - cuda-command-line-tools-11-2
+      - libcublas-11-2 
+      - libcublas-dev-11-2 
+      - cuda-nvrtc-11-2 
+      - cuda-nvrtc-dev-11-2 
+      - cuda-nvprune-11-2 
+      - cuda-cudart-dev-11-2 
+      - libcufft-dev-11-2 
+      - libcurand-dev-11-2 
+      - libcusolver-dev-11-2 
+      - libcusparse-dev-11-2 
+      - curl 
+      - git 
+      - libfreetype6-dev 
+      - libtool 
+      - libcudnn8=${CUDNN_VERSION}-1+cuda${CUDA} 
+      - libcudnn8-dev=${CUDNN_VERSION}-1+cuda${CUDA} 
+      - libcurl3-dev 
+      - libzmq3-dev 
+      - mlocate 
+      - openjdk-8-jdk
+      - openjdk-8-jre-headless 
+      - pkg-config 
+      - python-dev 
+      - software-properties-common 
+      - swig 
+      - unzip 
+      - wget 
+      - zip 
+      - zlib1g-dev 
+      - python3-distutils 
+      - python-distutils-extra
+      - python3.6
+      - python3.6-dev
+      - python3-pip
+      - python3.6-venv
+    build-environment:
+      - CUDNN_VERSION: "8.1.0.77"
+      - TF_TENSORRT_VERSION: "7.2.2"
+      - CUDA: "11.2"
+      - LD_LIBRARY_PATH: "/usr/local/cuda/extras/CUPTI/lib64:/usr/local/cuda/lib64:/usr/local/cuda/lib64/stubs:/usr/include/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH"
+      - BAZEL_VERSION: 3.7.2
+      - CI_BUILD_PYTHON: python
+      - TF_NEED_CUDA: 1
+      - TF_NEED_TENSORRT: 1
+      - TENSORRT_INSTALL_PATH: /usr/lib/x86_64-linux-gnu
+      - TF_CUDA_VERSION: 11.2
+      - TF_CUDNN_VERSION: 8
+      - TMP: /tmp
+      - TF_SERVING_BUILD_OPTIONS: --config=release
+
+    override-build:
+      find /usr/local/cuda-11.2/lib64/ -type f -name 'lib*_static.a' -not -name 'libcudart_static.a' -delete
+      rm /usr/lib/x86_64-linux-gnu/libcudnn_static_v8.a
+
+      apt-get update && \
+        apt-get install -y --no-install-recommends libnvinfer7=${TF_TENSORRT_VERSION}-1+cuda11.1 \
+        libnvinfer-dev=${TF_TENSORRT_VERSION}-1+cuda11.1 \
+        libnvinfer-plugin-dev=${TF_TENSORRT_VERSION}-1+cuda11.1 \
+        libnvinfer-plugin7=${TF_TENSORRT_VERSION}-1+cuda11.1 \
+        libnvonnxparsers7=${TF_TENSORRT_VERSION}-1+cuda11.1 \
+        libnvparsers7=${TF_TENSORRT_VERSION}-1+cuda11.1\
+        libnvonnxparsers-dev=${TF_TENSORRT_VERSION}-1+cuda11.1 \
+        libnvparsers-dev=${TF_TENSORRT_VERSION}-1+cuda11.1 \
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/*;
+
+      python3.6 -m pip install pip --upgrade
+
+      update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6
+      update-alternatives --install /usr/bin/python python /usr/bin/python3.6
+	
+      curl -fSsL -O https://bootstrap.pypa.io/get-pip.py
+
+      python3 get-pip.py
+
+      rm get-pip.py
+
+      pip3 --no-cache-dir install \
+        future>=0.17.1 \
+        grpcio \
+        h5py \
+        keras_applications>=1.0.8 \
+        keras_preprocessing>=1.1.0 \
+        mock \
+        numpy \
+        portpicker \
+        requests \
+        --ignore-installed six>=1.12.0
+
+      mkdir /bazel
+
+      cd bazel
+
+      curl -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36" -fSsL -O https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel-$BAZEL_VERSION-installer-linux-x86_64.sh
+
+      curl -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36" -fSsL -o /bazel/LICENSE.txt https://raw.githubusercontent.com/bazelbuild/bazel/master/LICENSE
+
+      chmod +x bazel-*.sh
+
+      ./bazel-$BAZEL_VERSION-installer-linux-x86_64.sh
+
+      cd ..
+
+      rm -f /bazel/bazel-$BAZEL_VERSION-installer-linux-x86_64.sh
+
+      # Fix paths so that CUDNN can be found: https://github.com/tensorflow/tensorflow/issues/8264
+      mkdir /usr/lib/x86_64-linux-gnu/include/
+      ln -s /usr/include/cudnn.h /usr/local/cuda/include/cudnn.h
+      ln -s /usr/lib/x86_64-linux-gnu/libcudnn.so /usr/local/cuda/lib64/libcudnn.so
+      ln -s /usr/lib/x86_64-linux-gnu/libcudnn.so.${TF_CUDNN_VERSION} /usr/local/cuda/lib64/libcudnn.so.${TF_CUDNN_VERSION}
+
+      export TF_NCCL_VERSION=
+
+      cd /tensorflow-serving
+
+      curl -sSL --retry 5 https://github.com/tensorflow/serving/tarball/${TF_SERVING_VERSION_GIT_COMMIT} | tar --strip-components=1 -xzf -
+
+      export TF_SERVING_BAZEL_OPTIONS=""
+
+      ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1
+      export LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:${LD_LIBRARY_PATH}
+
+      bazel build --color=yes --curses=yes --config=cuda --copt="-fPIC"\
+      ${TF_SERVING_BAZEL_OPTIONS} \
+      --verbose_failures \
+      --output_filter=DONT_MATCH_ANYTHING \
+      ${TF_SERVING_BUILD_OPTIONS} \
+      tensorflow_serving/model_servers:tensorflow_model_server
+
+      cp bazel-bin/tensorflow_serving/model_servers/tensorflow_model_server ${CRAFT_PART_INSTALL}/usr/local/bin/
+
+      rm /usr/local/cuda/lib64/stubs/libcuda.so.1
+
+      # Clean build
+      bazel clean --expunge --color=yes
+      rm -rf /root/.cache      
+      
+    stage-environment:
+      - CUDNN_VERSION: "8.1.0.77"
+      - TF_TENSORRT_VERSION: "7.2.2"
+      - CUDA: "11.2"
+      - LD_LIBRARY_PATH: "/usr/local/cuda/extras/CUPTI/lib64:$LD_LIBRARY_PATH"
+    override-stage: |
+      mkdir -p $CRAFT_PART_INSTALL/usr/bin/
+      cp 
+
+      
+    

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -158,7 +158,7 @@ parts:
       update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 0
       update-alternatives --install /usr/bin/python python /usr/bin/python3.6 0
       
-      curl -fSsL -O "https://bootstrap.pypa.io/get-pip.py"
+      curl -fSsL -O "https://bootstrap.pypa.io/pip/3.6/get-pip.py"
 
       python3 get-pip.py
 

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -95,14 +95,14 @@ parts:
       rm /usr/lib/x86_64-linux-gnu/libcudnn_static_v8.a
 
       apt-get update && \
-        apt-get install -y --no-install-recommends libnvinfer7=${TF_TENSORRT_VERSION}-1+cuda11.1 \
-        libnvinfer-dev=${TF_TENSORRT_VERSION}-1+cuda11.1 \
-        libnvinfer-plugin-dev=${TF_TENSORRT_VERSION}-1+cuda11.1 \
-        libnvinfer-plugin7=${TF_TENSORRT_VERSION}-1+cuda11.1 \
-        libnvonnxparsers7=${TF_TENSORRT_VERSION}-1+cuda11.1 \
-        libnvparsers7=${TF_TENSORRT_VERSION}-1+cuda11.1\
-        libnvonnxparsers-dev=${TF_TENSORRT_VERSION}-1+cuda11.1 \
-        libnvparsers-dev=${TF_TENSORRT_VERSION}-1+cuda11.1
+      apt-get install -y --no-install-recommends libnvinfer7=${TF_TENSORRT_VERSION}-1+cuda11.1 \
+      libnvinfer-dev=${TF_TENSORRT_VERSION}-1+cuda11.1 \
+      libnvinfer-plugin-dev=${TF_TENSORRT_VERSION}-1+cuda11.1 \
+      libnvinfer-plugin7=${TF_TENSORRT_VERSION}-1+cuda11.1 \
+      libnvonnxparsers7=${TF_TENSORRT_VERSION}-1+cuda11.1 \
+      libnvparsers7=${TF_TENSORRT_VERSION}-1+cuda11.1\
+      libnvonnxparsers-dev=${TF_TENSORRT_VERSION}-1+cuda11.1 \
+      libnvparsers-dev=${TF_TENSORRT_VERSION}-1+cuda11.1
       apt-get clean
       rm -rf /var/lib/apt/lists/*
 
@@ -118,21 +118,25 @@ parts:
       rm get-pip.py
 
       pip3 --no-cache-dir install \
-        future>=0.17.1 \
-        grpcio \
-        h5py \
-        keras_applications>=1.0.8 \
-        keras_preprocessing>=1.1.0 \
-        mock \
-        numpy \
-        portpicker \
-        requests \
-        --ignore-installed six>=1.12.0
+      future>=0.17.1 \
+      grpcio \
+      h5py \
+      keras_applications>=1.0.8 \
+      keras_preprocessing>=1.1.0 \
+      mock \
+      numpy \
+      portpicker \
+      requests \
+      --ignore-installed six>=1.12.0
 
       mkdir /bazel
 
       cd bazel
       
+      curl -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36" -fSsL -O https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh
+      
+      curl -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36" -fSsL -o /LICENSE.txt https://raw.githubusercontent.com/bazelbuild/bazel/master/LICENSE
+
       chmod +x bazel-*.sh
 
       ./bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -109,6 +109,9 @@ parts:
       apt-get clean
       rm -rf /var/lib/apt/lists/*
 
+      find /usr/local/cuda-11.2/lib64/ -type f -name 'lib*_static.a' -not -name 'libcudart_static.a' -delete
+      rm /usr/lib/x86_64-linux-gnu/libcudnn_static_v8.a
+
       # create Nvidia/CUDA directories
       mkdir -p "${CRAFT_PART_INSTALL}/usr/local" "${CRAFT_PART_INSTALL}/usr/local/bin"
 
@@ -132,15 +135,13 @@ parts:
       # tensorflow fix - some tensorflow tools expect a `python` binary
       # ln -s /usr/local/bin/python3 ${CRAFT_PART_INSTALL}/usr/local/bin/python
 
-      find /usr/local/cuda-11.2/lib64/ -type f -name 'lib*_static.a' -not -name 'libcudart_static.a' -delete
-      rm /usr/lib/x86_64-linux-gnu/libcudnn_static_v8.a
-
       # install - other nvidia stuff
       curl -sL "https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu2004/x86_64/7fa2af80.pub" | apt-key add -
       echo "deb https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu2004/x86_64 /" > /etc/apt/sources.list.d/nvidia-ml.list
       echo "deb https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64 /" > /etc/apt/sources.list.d/nvidia-ml.list
       apt-get -yq update
 
+      # NOTE: libnvinfer uses cuda11.1 versions
       apt-get install -y --no-install-recommends libnvinfer7=${TF_TENSORRT_VERSION}-1+cuda11.1 \
       libnvinfer-dev=${TF_TENSORRT_VERSION}-1+cuda${OLD_CUDA} \
       libnvinfer-plugin-dev=${TF_TENSORRT_VERSION}-1+cuda${OLD_CUDA} \
@@ -193,10 +194,10 @@ parts:
       rm -f /bazel/bazel-$BAZEL_VERSION-installer-linux-x86_64.sh
 
       # Fix paths so that CUDNN can be found: https://github.com/tensorflow/tensorflow/issues/8264
-      mkdir /usr/lib/x86_64-linux-gnu/include/
-      ln -s /usr/include/cudnn.h /usr/local/cuda/include/cudnn.h
-      ln -s /usr/lib/x86_64-linux-gnu/libcudnn.so /usr/local/cuda/lib64/libcudnn.so
-      ln -s /usr/lib/x86_64-linux-gnu/libcudnn.so.${TF_CUDNN_VERSION} /usr/local/cuda/lib64/libcudnn.so.${TF_CUDNN_VERSION}
+      mkdir ${CRAFT_PART_INSTALL}/usr/lib/x86_64-linux-gnu/include/
+      ln -s /usr/include/cudnn.h ${CRAFT_PART_INSTALL}/usr/local/cuda/include/cudnn.h
+      ln -s /usr/lib/x86_64-linux-gnu/libcudnn.so ${CRAFT_PART_INSTALL}/usr/local/cuda/lib64/libcudnn.so
+      ln -s /usr/lib/x86_64-linux-gnu/libcudnn.so.${TF_CUDNN_VERSION} ${CRAFT_PART_INSTALL}/usr/local/cuda/lib64/libcudnn.so.${TF_CUDNN_VERSION}
 
       export TF_NCCL_VERSION=
 

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -4,7 +4,7 @@ summary: TensorFlow model server
 description: Test
 version: v2.6.2
 license: Apache-2.0
-base: ubuntu@22.04
+base: ubuntu@20.04
 run-user: _daemon_
 platforms:
   amd64:
@@ -48,7 +48,7 @@ parts:
       - openjdk-8-jdk
       - openjdk-8-jre-headless 
       - pkg-config 
-      #- python-dev 
+      - python-dev 
       - software-properties-common 
       - swig 
       - unzip 
@@ -56,7 +56,7 @@ parts:
       - zip 
       - zlib1g-dev 
       - python3-distutils 
-      #- python-distutils-extra
+      - python-distutils-extra
       - python3-pip
     build-environment:
       - CUDNN_VERSION: "8.1.0.77"

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -108,7 +108,7 @@ parts:
 
       update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6
       update-alternatives --install /usr/bin/python python /usr/bin/python3.6
-	
+      
       curl -fSsL -O https://bootstrap.pypa.io/get-pip.py
 
       python3 get-pip.py

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -1,7 +1,7 @@
 # Based on https://github.com/tensorflow/serving/blob/master/tensorflow_serving/tools/docker/Dockerfile.gpu
 name: tensorflow-serving
 summary: TensorFlow model server
-description: Test
+description: TensorFlow Serving is a flexible, high-performance serving system for machine learning models, designed for production environments.
 version: v2.6.2
 license: Apache-2.0
 base: ubuntu@20.04

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -277,11 +277,11 @@ parts:
       echo '#!/bin/bash \n\n\
       tensorflow_model_server --port=8500 --rest_api_port=8501 \
       --model_name=${MODEL_NAME} --model_base_path=${MODEL_BASE_PATH}/${MODEL_NAME} \
-      "$@"' > ${CRAFT_PART_INSTALL}/usr/bin/tf_serving_entrypoint.sh
+      "$@"' > ${CRAFT_PART_SRC}/usr/bin/tf_serving_entrypoint.sh
 
     override-prime: |
       # copy all artifacts
-      cp ${CRAFT_PART_INSTALL}/usr/bin/tf_serving_entrypoint.sh /usr/bin/tf_serving_entrypoint.sh	
+      cp ${CRAFT_PART_SRC}/usr/bin/tf_serving_entrypoint.sh /usr/bin/tf_serving_entrypoint.sh	
 
       chmod +x /usr/bin/tf_serving_entrypoint.sh
 

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -102,9 +102,9 @@ parts:
         libnvonnxparsers7=${TF_TENSORRT_VERSION}-1+cuda11.1 \
         libnvparsers7=${TF_TENSORRT_VERSION}-1+cuda11.1\
         libnvonnxparsers-dev=${TF_TENSORRT_VERSION}-1+cuda11.1 \
-        libnvparsers-dev=${TF_TENSORRT_VERSION}-1+cuda11.1 \
-        && apt-get clean \
-        && rm -rf /var/lib/apt/lists/*;
+        libnvparsers-dev=${TF_TENSORRT_VERSION}-1+cuda11.1
+      apt-get clean
+      rm -rf /var/lib/apt/lists/*
 
       python3.6 -m pip install pip --upgrade
 

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -56,7 +56,7 @@ parts:
       - zip 
       - zlib1g-dev 
       - python3-distutils 
-      - python-distutils-extra
+      #- python-distutils-extra
       - python3-pip
     build-environment:
       - CUDNN_VERSION: "8.1.0.77"

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -273,6 +273,7 @@ parts:
       rm -rf /var/lib/apt/lists/*
       
       mkdir -p /models
+      mkdir -p ${CRAFT_PART_SRC}/usr/bin/
 
       echo '#!/bin/bash \n\n\
       tensorflow_model_server --port=8500 --rest_api_port=8501 \

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -5,6 +5,8 @@ version: v2.6.2
 license: Apache-2.0
 base: ubuntu@20.04
 run-user: _daemon_
+platforms:
+  amd64:
 services:
   serving:
     override: replace
@@ -13,11 +15,13 @@ services:
     environment:
        NVIDIA_VISIBLE_DEVICES: all
        NVIDIA_DRIVER_CAPABILITIES: "compute,utility"
+       MODEL_BASE_PATH=/models
+       MODEL_NAME=model
+       CUDA=11.2
+       TF_TENSORRT_VERSION=7.2.2
+       CUDNN_VERSION=8.1.0.77
        LD_LIBRARY_PATH: "/usr/local/nvidia/lib:/usr/local/nvidia/lib64"
-    command: ""
-platforms:
-  amd64:
-
+    command: "/usr/bin/tf_serving_entrypoint.sh [ ]"
 
 parts:
   security-team-requirement:
@@ -53,6 +57,14 @@ parts:
       - python3-distutils 
       - python-distutils-extra
       - python3-pip
+    stage-packages:
+      - ca-certificates
+    stage-environment:
+      - CUDA_LIB: "11-2"
+      - CUDA: "11.2"
+      - OLD_CUDA: "11.1"
+      - TF_TENSORRT_VERSION: "7.2.2"
+      - CUDNN_VERSION: "8.1.0.77"   
     build-environment:
       - CUDNN_VERSION: "8.1.0.77"
       - TF_TENSORRT_VERSION: "7.2.2"
@@ -90,8 +102,8 @@ parts:
         libcusparse-dev-${CUDA_LIB} \
         libfreetype6-dev \
         libtool \
-        libcudnn8=8.1.0.77-1+cuda${CUDA} \
-        libcudnn8-dev=8.1.0.77-1+cuda${CUDA} \
+        libcudnn8=${CUDNN_VERSION}-1+cuda${CUDA} \
+        libcudnn8-dev=${CUDNN_VERSION}-1+cuda${CUDA} \
         libcurl3-dev \
         libzmq3-dev \
         cuda-11-2
@@ -215,11 +227,58 @@ parts:
       ${TF_SERVING_BUILD_OPTIONS} \
       tensorflow_serving/model_servers:tensorflow_model_server
 
-      cp bazel-bin/tensorflow_serving/model_servers/tensorflow_model_server ${CRAFT_PART_INSTALL}/usr/local/bin/
+      cp bazel-bin/tensorflow_serving/model_servers/tensorflow_model_server ${CRAFT_PART_INSTALL}/usr/bin/
 
       rm /usr/local/cuda/lib64/stubs/libcuda.so.1
 
+      bazel build --color=yes --curses=yes \
+      ${TF_SERVING_BAZEL_OPTIONS} \
+      --verbose_failures \
+      --output_filter=DONT_MATCH_ANYTHING \
+      ${TF_SERVING_BUILD_OPTIONS} \
+      tensorflow_serving/tools/pip_package:build_pip_package && \
+      bazel-bin/tensorflow_serving/tools/pip_package/build_pip_package \
+      /tmp/pip
+      
+      pip --no-cache-dir install --upgrade /tmp/pip/tensorflow_serving_api_gpu-*.whl
+      
+      rm -rf /tmp/pip
+
       # Clean build
       bazel clean --expunge --color=yes
-      rm -rf /root/.cache      
+      rm -rf /root/.cache
+
+    override-stage:
+      set -xe
+
+      curl -sL "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub" | apt-key add -
+      echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /" > /etc/apt/sources.list.d/cuda.list
+      apt-get -yq update
+      
+      apt-get install -yq --no-install-recommends \
+        cuda-command-line-tools-${CUDA_LIB} \ +
+        libcublas-${CUDA_LIB} \ +
+        libcublas-dev-${CUDA_LIB} \ +
+	libcufft-${CUDA_LIB} \ +
+        libcurand-${CUDA_LIB} \ +
+        libcusolver-${CUDA_LIB} \ +
+        libcusparse-${CUDA_LIB} \ +
+        libcudnn8=${CUDNN_VERSION}-1+cuda${CUDA} \
+        libgomp1 \
+	libnvinfer7=${TF_TENSORRT_VERSION}-1+cuda${OLD_CUDA} \
+	libnvinfer-plugin7=${TF_TENSORRT_VERSION}-1+cuda${OLD_CUDA}
+
+      apt-get clean
+
+      rm -rf /var/lib/apt/lists/*
+      
+      mkdir -p /models
+
+      echo '#!/bin/bash \n\n\
+      tensorflow_model_server --port=8500 --rest_api_port=8501 \
+      --model_name=${MODEL_NAME} --model_base_path=${MODEL_BASE_PATH}/${MODEL_NAME} \
+      "$@"' > ${CRAFT_PART_INSTALL}/usr/bin/tf_serving_entrypoint.sh
+
+      chmod +x ${CRAFT_PART_INSTALL}/usr/bin/tf_serving_entrypoint.sh
+
 

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -256,13 +256,13 @@ parts:
       apt-get -yq update
       
       apt-get install -yq --no-install-recommends \
-        cuda-command-line-tools-${CUDA_LIB} \ +
-        libcublas-${CUDA_LIB} \ +
-        libcublas-dev-${CUDA_LIB} \ +
-	libcufft-${CUDA_LIB} \ +
-        libcurand-${CUDA_LIB} \ +
-        libcusolver-${CUDA_LIB} \ +
-        libcusparse-${CUDA_LIB} \ +
+        cuda-command-line-tools-${CUDA_LIB} \
+        libcublas-${CUDA_LIB} \
+        libcublas-dev-${CUDA_LIB} \
+	libcufft-${CUDA_LIB} \
+        libcurand-${CUDA_LIB} \
+        libcusolver-${CUDA_LIB} \
+        libcusparse-${CUDA_LIB} \
         libcudnn8=${CUDNN_VERSION}-1+cuda${CUDA} \
         libgomp1 \
 	libnvinfer7=${TF_TENSORRT_VERSION}-1+cuda${OLD_CUDA} \

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -94,7 +94,7 @@ parts:
         libcudnn8-dev=8.1.0.77-1+cuda${CUDA} \
         libcurl3-dev \
         libzmq3-dev \
-	cuda-11.2
+	cuda-11-2
 
       apt-get clean
       rm -rf /var/lib/apt/lists/*

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -1,7 +1,6 @@
 name: tensorflow-serving
 summary: TensorFlow model server
-description: |
-None
+description: Test
 version: v2.6.2
 license: Apache-2.0
 base: ubuntu:22.04

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -279,6 +279,9 @@ parts:
       --model_name=${MODEL_NAME} --model_base_path=${MODEL_BASE_PATH}/${MODEL_NAME} \
       "$@"' > ${CRAFT_PART_INSTALL}/usr/bin/tf_serving_entrypoint.sh
 
-      chmod +x ${CRAFT_PART_INSTALL}/usr/bin/tf_serving_entrypoint.sh
+    override-prime: |
+      # copy all artifacts
+      cp -r ${CRAFT_STAGE}/usr/bin/tf_serving_entrypoint.sh /usr/bin/tf_serving_entrypoint.sh
 
+      chmod +x /usr/bin/tf_serving_entrypoint.sh
 

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -133,10 +133,6 @@ parts:
 
       cd bazel
       
-      curl -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36" -fSsL -O https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh
-      
-      curl -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36" -fSsL -o /LICENSE.txt https://raw.githubusercontent.com/bazelbuild/bazel/master/LICENSE
-
       chmod +x bazel-*.sh
 
       ./bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -15,7 +15,7 @@ services:
        NVIDIA_VISIBLE_DEVICES: all
        NVIDIA_DRIVER_CAPABILITIES: compute,utility
        LD_LIBRARY_PATH: /usr/local/nvidia/lib:/usr/local/nvidia/lib64
-    command: nil
+    command: ""
 platforms:
   amd64:
 

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -94,7 +94,7 @@ parts:
         libcudnn8-dev=8.1.0.77-1+cuda${CUDA} \
         libcurl3-dev \
         libzmq3-dev \
-	cuda-11-2
+        cuda-11-2
 
       apt-get clean
       rm -rf /var/lib/apt/lists/*

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -1,9 +1,10 @@
+# Based on https://github.com/tensorflow/serving/blob/master/tensorflow_serving/tools/docker/Dockerfile.gpu
 name: tensorflow-serving
 summary: TensorFlow model server
 description: Test
 version: v2.6.2
 license: Apache-2.0
-base: ubuntu@20.04
+base: ubuntu@22.04
 run-user: _daemon_
 platforms:
   amd64:
@@ -32,7 +33,7 @@ parts:
       dpkg-query -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
       > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
       
-  cuda-build:
+  tf-serving:
     plugin: nil
     source: https://github.com/tensorflow/serving
     source-type: git

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -203,7 +203,7 @@ parts:
 
       export TF_NCCL_VERSION=
 
-      cd /tensorflow-serving
+      cd /tensorflow_serving
 
       export TF_SERVING_BAZEL_OPTIONS=""
 

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -128,22 +128,6 @@ parts:
       cp -rp /usr/local/cuda-${CUDA} ${CRAFT_PART_INSTALL}/usr/local
       ln -sf /usr/local/cuda-${CUDA} ${CRAFT_PART_INSTALL}/usr/local/cuda
 
-      # tensorflow fix - wrong libcuda lib path (+ reconfigure dynamic linker run-time bindings)
-      # ln -s /usr/local/cuda/lib64/stubs/libcuda.so ${CRAFT_PART_INSTALL}/usr/local/cuda/lib64/stubs/libcuda.so.1
-      # echo "/usr/local/cuda/lib64/stubs" > /etc/ld.so.conf.d/z-cuda-stubs.conf
-      # ldconfig
-
-      # copy CUDA config
-      # mkdir -p ${CRAFT_PART_INSTALL}/etc/ld.so.conf.d/
-      # cp -r /etc/ld.so.conf.d/z-cuda-stubs.conf ${CRAFT_PART_INSTALL}/etc/ld.so.conf.d/z-cuda-stubs.conf
-
-      # tensorflow fix - wrong libcusolver lib path
-      # https://github.com/tensorflow/tensorflow/issues/43947#issuecomment-748273679
-      # ln -s /usr/local/cuda-${CUDA}/targets/x86_64-linux/lib/libcusolver.so.11 ${CRAFT_PART_INSTALL}/usr/local/cuda-${CUDA}/targets/x86_64-linux/lib/libcusolver.so.10
-
-      # tensorflow fix - some tensorflow tools expect a `python` binary
-      # ln -s /usr/local/bin/python3 ${CRAFT_PART_INSTALL}/usr/local/bin/python
-
       # install - other nvidia stuff
       curl -sL "https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu2004/x86_64/7fa2af80.pub" | apt-key add -
       echo "deb https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu2004/x86_64 /" > /etc/apt/sources.list.d/nvidia-ml.list

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -176,9 +176,9 @@ parts:
       requests \
       --ignore-installed six>=1.12.0
 
-      mkdir /bazel
+      mkdir ./bazel
 
-      cd bazel
+      cd bazel/
       
       curl -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36" -fSsL -O https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh
       
@@ -201,8 +201,6 @@ parts:
       export TF_NCCL_VERSION=
 
       cd /tensorflow-serving
-
-      curl -sSL --retry 5 https://github.com/tensorflow/serving/tarball/${TF_SERVING_VERSION_GIT_COMMIT} | tar --strip-components=1 -xzf -
 
       export TF_SERVING_BAZEL_OPTIONS=""
 

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -208,9 +208,9 @@ parts:
       export TF_SERVING_BAZEL_OPTIONS=""
 
       ln -s /usr/local/cuda-${CUDA}/lib64/stubs/libcuda.so /usr/local/cuda-${CUDA}/lib64/stubs/libcuda.so.1
-      export LD_LIBRARY_PATH=/usr/local/cuda-${CUDA}/lib64/stubs:${LD_LIBRARY_PATH}
-
-      bazel build --color=yes --curses=yes --config=cuda --copt="-fPIC"\
+      
+      LD_LIBRARY_PATH=/usr/local/cuda-${CUDA}/lib64/stubs:${LD_LIBRARY_PATH} \
+      bazel build --color=yes --curses=yes --config=cuda --copt="-fPIC" \
       ${TF_SERVING_BAZEL_OPTIONS} \
       --verbose_failures \
       --output_filter=DONT_MATCH_ANYTHING \

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -93,7 +93,8 @@ parts:
         libcudnn8=8.1.0.77-1+cuda${CUDA} \
         libcudnn8-dev=8.1.0.77-1+cuda${CUDA} \
         libcurl3-dev \
-        libzmq3-dev
+        libzmq3-dev \
+	cuda-11.2
 
       apt-get clean
       rm -rf /var/lib/apt/lists/*

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -48,7 +48,7 @@ parts:
       - openjdk-8-jdk
       - openjdk-8-jre-headless 
       - pkg-config 
-      - python-dev 
+      #- python-dev 
       - software-properties-common 
       - swig 
       - unzip 

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -14,7 +14,7 @@ services:
     environment:
        NVIDIA_VISIBLE_DEVICES: all
        NVIDIA_DRIVER_CAPABILITIES: "compute,utility"
-       LD_LIBRARY_PATH: /usr/local/nvidia/lib:/usr/local/nvidia/lib64
+       LD_LIBRARY_PATH: "/usr/local/nvidia/lib:/usr/local/nvidia/lib64"
     command: ""
 platforms:
   amd64:
@@ -53,8 +53,8 @@ parts:
       - git 
       - libfreetype6-dev 
       - libtool 
-      - libcudnn8=${CUDNN_VERSION}-1+cuda${CUDA} 
-      - libcudnn8-dev=${CUDNN_VERSION}-1+cuda${CUDA} 
+      - libcudnn8=8.1.0.77-1+cuda11.2
+      - libcudnn8-dev=8.1.0.77-1+cuda11.2
       - libcurl3-dev 
       - libzmq3-dev 
       - mlocate 
@@ -87,7 +87,7 @@ parts:
       - TF_CUDA_VERSION: 11.2
       - TF_CUDNN_VERSION: 8
       - TMP: /tmp
-      - TF_SERVING_BUILD_OPTIONS: --config=release
+      - TF_SERVING_BUILD_OPTIONS: "--config=release"
 
     override-build:
       find /usr/local/cuda-11.2/lib64/ -type f -name 'lib*_static.a' -not -name 'libcudart_static.a' -delete

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -146,7 +146,7 @@ parts:
       libnvinfer-plugin-dev=${TF_TENSORRT_VERSION}-1+cuda${OLD_CUDA} \
       libnvinfer-plugin7=${TF_TENSORRT_VERSION}-1+cuda${OLD_CUDA} \
       libnvonnxparsers7=${TF_TENSORRT_VERSION}-1+cuda${OLD_CUDA} \
-      libnvparsers7=${TF_TENSORRT_VERSION}-1+cuda${OLD_CUDA}\
+      libnvparsers7=${TF_TENSORRT_VERSION}-1+cuda${OLD_CUDA} \
       libnvonnxparsers-dev=${TF_TENSORRT_VERSION}-1+cuda${OLD_CUDA} \
       libnvparsers-dev=${TF_TENSORRT_VERSION}-1+cuda${OLD_CUDA}
       

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -20,7 +20,7 @@ services:
        CUDA: "11.2"
        TF_TENSORRT_VERSION: "7.2.2"
        CUDNN_VERSION: "8.1.0.77"
-       LD_LIBRARY_PATH: "/usr/local/nvidia/lib:/usr/local/nvidia/lib64"
+       LD_LIBRARY_PATH: "/usr/local/cuda/lib:/usr/local/cuda/lib64"
     command: "tensorflow_model_server --port=8500 --rest_api_port=8501 --model_name=${MODEL_NAME} --model_base_path=${MODEL_BASE_PATH}/${MODEL_NAME} [ ]"
 
 parts:

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -3,7 +3,7 @@ summary: TensorFlow model server
 description: Test
 version: v2.6.2
 license: Apache-2.0
-base: ubuntu:22.04
+base: ubuntu@22.04
 run-user: _daemon_
 services:
   serving:
@@ -80,17 +80,17 @@ parts:
       - LD_LIBRARY_PATH: "/usr/local/cuda/extras/CUPTI/lib64:/usr/local/cuda/lib64:/usr/local/cuda/lib64/stubs:/usr/include/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH"
       - BAZEL_VERSION: 3.7.2
       - CI_BUILD_PYTHON: python
-      - TF_NEED_CUDA: 1
-      - TF_NEED_TENSORRT: 1
+      - TF_NEED_CUDA: "1"
+      - TF_NEED_TENSORRT: "1"
       - TENSORRT_INSTALL_PATH: /usr/lib/x86_64-linux-gnu
-      - TF_CUDA_VERSION: 11.2
-      - TF_CUDNN_VERSION: 8
+      - TF_CUDA_VERSION: "11.2"
+      - TF_CUDNN_VERSION: "8"
       - TMP: /tmp
       - TF_SERVING_BUILD_OPTIONS: "--config=release"
 
-    override-build:
+    override-build: |
       set -xe
-      
+
       find /usr/local/cuda-11.2/lib64/ -type f -name 'lib*_static.a' -not -name 'libcudart_static.a' -delete
       rm /usr/lib/x86_64-linux-gnu/libcudnn_static_v8.a
 
@@ -111,7 +111,7 @@ parts:
       update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6
       update-alternatives --install /usr/bin/python python /usr/bin/python3.6
       
-      curl -fSsL -O https://bootstrap.pypa.io/get-pip.py
+      curl -fSsL -O "https://bootstrap.pypa.io/get-pip.py"
 
       python3 get-pip.py
 
@@ -177,11 +177,6 @@ parts:
       bazel clean --expunge --color=yes
       rm -rf /root/.cache      
       
-    stage-environment:
-      - CUDNN_VERSION: "8.1.0.77"
-      - TF_TENSORRT_VERSION: "7.2.2"
-      - CUDA: "11.2"
-      - LD_LIBRARY_PATH: "/usr/local/cuda/extras/CUPTI/lib64:$LD_LIBRARY_PATH"
     override-stage: |
       mkdir -p $CRAFT_PART_INSTALL/usr/bin/
       exit 1

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -259,14 +259,14 @@ parts:
         cuda-command-line-tools-${CUDA_LIB} \
         libcublas-${CUDA_LIB} \
         libcublas-dev-${CUDA_LIB} \
-	libcufft-${CUDA_LIB} \
+        libcufft-${CUDA_LIB} \
         libcurand-${CUDA_LIB} \
         libcusolver-${CUDA_LIB} \
         libcusparse-${CUDA_LIB} \
         libcudnn8=${CUDNN_VERSION}-1+cuda${CUDA} \
         libgomp1 \
-	libnvinfer7=${TF_TENSORRT_VERSION}-1+cuda${OLD_CUDA} \
-	libnvinfer-plugin7=${TF_TENSORRT_VERSION}-1+cuda${OLD_CUDA}
+        libnvinfer7=${TF_TENSORRT_VERSION}-1+cuda${OLD_CUDA} \
+        libnvinfer-plugin7=${TF_TENSORRT_VERSION}-1+cuda${OLD_CUDA}
 
       apt-get clean
 

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -155,8 +155,8 @@ parts:
       
       python3.6 -m pip install pip --upgrade      
 
-      update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6
-      update-alternatives --install /usr/bin/python python /usr/bin/python3.6
+      update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 0
+      update-alternatives --install /usr/bin/python python /usr/bin/python3.6 0
       
       curl -fSsL -O "https://bootstrap.pypa.io/get-pip.py"
 

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -57,14 +57,6 @@ parts:
       - python3-distutils 
       - python-distutils-extra
       - python3-pip
-    stage-packages:
-      - ca-certificates
-    stage-environment:
-      - CUDA_LIB: "11-2"
-      - CUDA: "11.2"
-      - OLD_CUDA: "11.1"
-      - TF_TENSORRT_VERSION: "7.2.2"
-      - CUDNN_VERSION: "8.1.0.77"   
     build-environment:
       - CUDNN_VERSION: "8.1.0.77"
       - TF_TENSORRT_VERSION: "7.2.2"
@@ -81,6 +73,14 @@ parts:
       - TF_CUDNN_VERSION: "8"
       - TMP: /tmp
       - TF_SERVING_BUILD_OPTIONS: "--config=release"
+    stage-packages:
+      - ca-certificates
+    stage-environment:
+      - CUDA_LIB: "11-2"
+      - CUDA: "11.2"
+      - OLD_CUDA: "11.1"
+      - TF_TENSORRT_VERSION: "7.2.2"
+      - CUDNN_VERSION: "8.1.0.77"      
     override-build: |
       set -xe
 

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -238,7 +238,7 @@ parts:
       bazel-bin/tensorflow_serving/tools/pip_package/build_pip_package \
       /tmp/pip
 
-      mkdir -p ${CRAFT_PART_INSTALL}/models
+      mkdir -p ${CRAFT_PART_INSTALL}/models/model
       
       pip --no-cache-dir install --upgrade /tmp/pip/tensorflow_serving_api_gpu-*.whl
       

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -118,7 +118,7 @@ parts:
       rm -rf /var/lib/apt/lists/*
 
       find /usr/local/cuda-11.2/lib64/ -type f -name 'lib*_static.a' -not -name 'libcudart_static.a' -delete
-      rm /usr/lib/x86_64-linux-gnu/libcudnn_static_v8.a
+      rm -f /usr/lib/x86_64-linux-gnu/libcudnn_static_v8.a
 
       # create Nvidia/CUDA directories
       mkdir -p "${CRAFT_PART_INSTALL}/usr/local" "${CRAFT_PART_INSTALL}/usr/local/bin"
@@ -173,7 +173,7 @@ parts:
 
       python3 get-pip.py
 
-      rm get-pip.py
+      rm -f get-pip.py
 
       pip3 --no-cache-dir install \
       future>=0.17.1 \
@@ -224,7 +224,7 @@ parts:
 
       cp bazel-bin/tensorflow_serving/model_servers/tensorflow_model_server ${CRAFT_PART_INSTALL}/usr/bin/
 
-      rm /usr/local/cuda/lib64/stubs/libcuda.so.1
+      rm -f /usr/local/cuda/lib64/stubs/libcuda.so.1
 
       # Patch for deprecated python tensorflow-gpu package
       sed -i '49,52d' tensorflow_serving/tools/pip_package/setup.py
@@ -246,11 +246,13 @@ parts:
       bazel clean --expunge --color=yes
       rm -rf /root/.cache
 
-    override-stage:
+    override-stage: |
       set -xe
 
       curl -sL "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub" | apt-key add -
+      
       echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /" > /etc/apt/sources.list.d/cuda.list
+      
       apt-get -yq update
       
       apt-get install -yq --no-install-recommends \

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -13,7 +13,7 @@ services:
     startup: enabled
     environment:
        NVIDIA_VISIBLE_DEVICES: all
-       NVIDIA_DRIVER_CAPABILITIES: compute,utility
+       NVIDIA_DRIVER_CAPABILITIES: "compute,utility"
        LD_LIBRARY_PATH: /usr/local/nvidia/lib:/usr/local/nvidia/lib64
     command: ""
 platforms:
@@ -183,7 +183,6 @@ parts:
       - LD_LIBRARY_PATH: "/usr/local/cuda/extras/CUPTI/lib64:$LD_LIBRARY_PATH"
     override-stage: |
       mkdir -p $CRAFT_PART_INSTALL/usr/bin/
-      cp 
-
+      exit 1
       
     

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -131,7 +131,7 @@ parts:
 
       cd bazel
 
-      curl -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36" -fSsL -O https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel-$BAZEL_VERSION-installer-linux-x86_64.sh
+      curl -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36" -fSsL -O https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh
 
       curl -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36" -fSsL -o /bazel/LICENSE.txt https://raw.githubusercontent.com/bazelbuild/bazel/master/LICENSE
 

--- a/tensorflow-serving/rockcraft.yaml
+++ b/tensorflow-serving/rockcraft.yaml
@@ -237,6 +237,16 @@ parts:
       tensorflow_serving/tools/pip_package:build_pip_package && \
       bazel-bin/tensorflow_serving/tools/pip_package/build_pip_package \
       /tmp/pip
+
+      mkdir -p ${CRAFT_PART_INSTALL}/models
+
+      echo '#!/bin/bash \n\n\
+      tensorflow_model_server --port=8500 --rest_api_port=8501 \
+      --model_name=${MODEL_NAME} --model_base_path=${MODEL_BASE_PATH}/${MODEL_NAME} \
+      "$@"' > ${CRAFT_PART_INSTALL}/usr/bin/tf_serving_entrypoint.sh
+
+      chmod +x ${CRAFT_PART_INSTALL}/usr/bin/tf_serving_entrypoint.sh
+
       
       pip --no-cache-dir install --upgrade /tmp/pip/tensorflow_serving_api_gpu-*.whl
       
@@ -246,43 +256,4 @@ parts:
       bazel clean --expunge --color=yes
       rm -rf /root/.cache
 
-    override-stage: |
-      set -xe
-
-      curl -sL "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub" | apt-key add -
-      
-      echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /" > /etc/apt/sources.list.d/cuda.list
-      
-      apt-get -yq update
-      
-      apt-get install -yq --no-install-recommends \
-        cuda-command-line-tools-${CUDA_LIB} \
-        libcublas-${CUDA_LIB} \
-        libcublas-dev-${CUDA_LIB} \
-        libcufft-${CUDA_LIB} \
-        libcurand-${CUDA_LIB} \
-        libcusolver-${CUDA_LIB} \
-        libcusparse-${CUDA_LIB} \
-        libcudnn8=${CUDNN_VERSION}-1+cuda${CUDA} \
-        libgomp1 \
-        libnvinfer7=${TF_TENSORRT_VERSION}-1+cuda${OLD_CUDA} \
-        libnvinfer-plugin7=${TF_TENSORRT_VERSION}-1+cuda${OLD_CUDA}
-
-      apt-get clean
-
-      rm -rf /var/lib/apt/lists/*
-      
-      mkdir -p /models
-      mkdir -p ${CRAFT_PART_SRC}/usr/bin/
-
-      echo '#!/bin/bash \n\n\
-      tensorflow_model_server --port=8500 --rest_api_port=8501 \
-      --model_name=${MODEL_NAME} --model_base_path=${MODEL_BASE_PATH}/${MODEL_NAME} \
-      "$@"' > ${CRAFT_PART_SRC}/usr/bin/tf_serving_entrypoint.sh
-
-    override-prime: |
-      # copy all artifacts
-      cp ${CRAFT_PART_SRC}/usr/bin/tf_serving_entrypoint.sh /usr/bin/tf_serving_entrypoint.sh	
-
-      chmod +x /usr/bin/tf_serving_entrypoint.sh
 

--- a/tensorflow-serving/tests/test_rock.py
+++ b/tensorflow-serving/tests/test_rock.py
@@ -17,7 +17,6 @@ from charmed_kubeflow_chisme.rock import CheckRock
 @pytest.mark.abort_on_fail
 def test_rock():
     """Test rock."""
-    temp_dir, container_name = rock_test_env
     check_rock = CheckRock("rockcraft.yaml")
     rock_image = check_rock.get_name()
     rock_version = check_rock.get_version()

--- a/tensorflow-serving/tests/test_rock.py
+++ b/tensorflow-serving/tests/test_rock.py
@@ -15,7 +15,7 @@ from charmed_kubeflow_chisme.rock import CheckRock
 
 
 @pytest.mark.abort_on_fail
-def test_rock(rock_test_env):
+def test_rock():
     """Test rock."""
     temp_dir, container_name = rock_test_env
     check_rock = CheckRock("rockcraft.yaml")

--- a/tensorflow-serving/tests/test_rock.py
+++ b/tensorflow-serving/tests/test_rock.py
@@ -1,0 +1,38 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from pathlib import Path
+
+import os
+import logging
+import random
+import pytest
+import string
+import subprocess
+import yaml
+
+from charmed_kubeflow_chisme.rock import CheckRock
+
+
+@pytest.mark.abort_on_fail
+def test_rock(rock_test_env):
+    """Test rock."""
+    temp_dir, container_name = rock_test_env
+    check_rock = CheckRock("rockcraft.yaml")
+    rock_image = check_rock.get_name()
+    rock_version = check_rock.get_version()
+    LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
+
+    # assert we have the expected files
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /usr/bin/tensorflow_model_server",
+        ],
+        check=True,
+    )

--- a/tensorflow-serving/tox.ini
+++ b/tensorflow-serving/tox.ini
@@ -1,0 +1,54 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+[tox]
+skipsdist = True
+skip_missing_interpreters = True
+envlist = pack, export-to-docker, sanity, integration
+
+[testenv]
+setenv =
+    PYTHONPATH={toxinidir}
+    PYTHONBREAKPOINT=ipdb.set_trace
+    CHARM_REPO=https://github.com/canonical/kserve-operators.git
+    CHARM_BRANCH=main
+    LOCAL_CHARM_DIR=charm_repo
+
+[testenv:pack]
+passenv = *
+allowlist_externals =
+    rockcraft
+commands =
+    rockcraft pack
+
+[testenv:export-to-docker]
+passenv = *
+allowlist_externals =
+    bash
+    skopeo
+    yq
+commands =
+    # pack rock and export to docker
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval ".platforms | keys | .[0]" rockcraft.yaml) && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
+             DOCKER_IMAGE=$NAME:$VERSION && \
+             echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
+             skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+
+[testenv:sanity]
+passenv = *
+deps =
+    pytest
+    charmed-kubeflow-chisme
+commands =
+    # run rock tests
+    pytest -s -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
+
+[testenv:integration]
+passenv = *
+allowlist_externals =
+    echo
+commands =
+    # TODO: Implement integration tests here
+    echo "WARNING: This is a placeholder test - no test is implemented here."


### PR DESCRIPTION
### Description
---
* Add rockcraft.yaml
* Add tests
* Add tox.ini

Logs from tests
---
`juju status` after all tests are passed:
```
Model     Controller          Cloud/Region        Version  SLA          Timestamp
kubeflow  microk8s-localhost  microk8s/localhost  3.6.1    unsupported  16:43:45Z

App                      Version                Status   Scale  Charm                    Channel          Rev  Address         Exposed  Message
grafana-agent-k8s        0.32.1                 blocked      1  grafana-agent-k8s        latest/stable     45  10.152.183.119  no       grafana-cloud-config: off, logging-consumer: off
istio-ingressgateway                            active       1  istio-gateway            1.16/stable     1005  10.152.183.215  no       
istio-pilot                                     active       1  istio-pilot              1.16/stable      662  10.152.183.134  no       
knative-operator                                active       1  knative-operator         latest/edge      542  10.152.183.173  no       
knative-serving                                 active       1  knative-serving          latest/edge      572  10.152.183.32   no       
kserve-controller                               blocked      1  kserve-controller                           0  10.152.183.76   no       Cannot parse a config-defined images list from config '{' - thisconfig input will be ignored.
metacontroller-operator                         active       1  metacontroller-operator  latest/edge      401  10.152.183.244  no       
minio                    res:oci-image@1755999  active       1  minio                    ckf-1.7/stable   214  10.152.183.233  no       
resource-dispatcher                             active       1  resource-dispatcher      latest/edge      236  10.152.183.19   no       

Unit                        Workload  Agent  Address      Ports          Message
grafana-agent-k8s/0*        blocked   idle   10.1.172.44                 grafana-cloud-config: off, logging-consumer: off
istio-ingressgateway/0*     active    idle   10.1.172.50                 
istio-pilot/0*              active    idle   10.1.172.3                  
knative-operator/0*         active    idle   10.1.172.58                 
knative-serving/0*          active    idle   10.1.172.7                  
kserve-controller/0*        blocked   idle   10.1.172.53                 Cannot parse a config-defined images list from config '{' - thisconfig input will be ignored.
metacontroller-operator/0*  active    idle   10.1.172.4                  
minio/0*                    active    idle   10.1.172.43  9000-9001/TCP  
resource-dispatcher/0*      active    idle   10.1.172.18                 
```

Logs of passed integration tests `tox -vve integration -- --model kubeflow --keep-models` (only last included due to PR message maximum length):
```
======================================================================================= 18 passed in 1258.97s (0:20:58) ========================================================================================
integration: 1260959 I exit 0 (1260.60 seconds) /home/ubuntu/kserve-operators/charms/kserve-controller> pytest -v --tb native --ignore=/home/ubuntu/kserve-operators/charms/kserve-controller/tests/unit --log-cli-level=INFO -s --model kubeflow --keep-models pid=1197212 [tox/execute/api.py:286]
  integration: OK (1260.67=setup[0.07]+cmd[1260.60] seconds)
  congratulations :) (1260.78 seconds)
```