### PR TITLE
Add `torchserve-kfs` rock and tests

### DIFF
--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -18,7 +18,7 @@ platforms:
 run-user: _daemon_
 services:
   torchserve:
-    override: 
+    override: replace
     summary: "TorchServe service"
     startup: enabled
     command: "/usr/local/bin/dockerd-entrypoint.sh [ ]"

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -129,6 +129,7 @@ parts:
       chown -R 584792:users $CRAFT_PRIME/home/model-server
       chown -R 584792:users $CRAFT_PRIME/home/venv
       chown -R 584792:users $CRAFT_PRIME/usr/local/bin/dockerd-entrypoint.sh
+      chown -R 584792:users $CRAFT_PRIME/bin
       chmod -R g+rwx $CRAFT_PRIME/home/model-server
 
       sed -i '/^daemon:/s|:/usr/sbin:|:/home/model-server:|' /etc/passwd

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -114,10 +114,12 @@ parts:
     after: [torchserve-kfs]
     overlay-script: |
       # Create a user in the $CRAFT_OVERLAY chroot
-      useradd -R $CRAFT_OVERLAY -M -s /bin/bash -N -u 1001 model-server
+      useradd -R $CRAFT_OVERLAY -M -s /bin/bash -N -u 1001 -G users model-server
     override-prime: |
       craftctl default
       chown -R 584792:users home/model-server
       chown -R 584792:users home/venv
+      chmod -R g+rwx home/model-server
+
 
      

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -130,12 +130,10 @@ parts:
       chown -R 584792:users $CRAFT_PRIME/home/model-server
       chown -R 584792:users $CRAFT_PRIME/home/venv
       chown -R 584792:users $CRAFT_PRIME/usr/local/bin/dockerd-entrypoint.sh
-      chown -R 584792:users $CRAFT_PRIME/bin/bash
       chmod -R g+rwx $CRAFT_PRIME/home/model-server
 
-      touch $CRAFT_PRIME/key_file.json
-      chown -R 584792:users $CRAFT_PRIME/key_file.json
-      chmod -R g+rwx $CRAFT_PRIME/key_file.json
+      cp ${CRAFT_STAGE}/bin/bash ${CRAFT_PRIME}/bin/bash
+      chown -R 584792:users $CRAFT_PRIME/bin/bash
 
       # Fix for _daemon_ user to allow to start dockerd-entrypoint.sh
       # sed -i '3i cd "/home/model-server"' $CRAFT_PRIME/usr/local/bin/dockerd-entrypoint.sh

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -131,7 +131,7 @@ parts:
       chmod -R g+rwx $CRAFT_PRIME/home/model-server
 
       # Fix for _daemon_ user to allow to start dockerd-entrypoint.sh
-      # usermod -d $CRAFT_PRIME/home/model-server _daemon_
+      sed -i '3i cd "/home/model-server"' $CRAFT_PRIME/usr/local/bin/dockerd-entrypoint.sh
 
 
      

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -130,5 +130,8 @@ parts:
       chown -R 584792:users $CRAFT_PRIME/usr/local/bin/dockerd-entrypoint.sh
       chmod -R g+rwx $CRAFT_PRIME/home/model-server
 
+      # Fix for _daemon_ user to allow to start dockerd-entrypoint.sh
+      usermod -d $CRAFT_PRIME/home/model-server 584792
+
 
      

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -75,7 +75,11 @@ parts:
       cp -r ${CRAFT_PART_SRC}/docker/dockerd-entrypoint.sh ${CRAFT_PART_INSTALL}/usr/local/bin/dockerd-entrypoint.sh
 
       # Pebble do not have access to `tail` command
-      sed -i 's|tail -f /dev/null|while true; do\n    sleep 3600\ndone|' ${CRAFT_PART_INSTALL}/usr/local/bin/dockerd-entrypoint.sh
+      sed -i '/tail -f \/dev\/null/d' ${CRAFT_PART_INSTALL}/usr/local/bin/dockerd-entrypoint.sh
+
+      # Add `--foreground` flag as a replacement for `tail`
+      sed -i 's/torchserve --start/torchserve --start --foreground/' ${CRAFT_PART_INSTALL}/usr/local/bin/dockerd-entrypoint.sh
+
       chmod +x ${CRAFT_PART_INSTALL}/usr/local/bin/dockerd-entrypoint.sh
 
       mkdir -p ${CRAFT_PART_INSTALL}/home/model-server/tmp

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -127,6 +127,7 @@ parts:
       craftctl default
       chown -R 584792:users home/model-server
       chown -R 584792:users home/venv
+      chown -R 584792:users $CRAFT_PRIME/usr/local/bin/docker-entrypoint.sh
       chmod -R g+rwx home/model-server
 
 

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -127,7 +127,7 @@ parts:
       craftctl default
       chown -R 584792:users home/model-server
       chown -R 584792:users home/venv
-      chown -R 584792:users $CRAFT_PRIME/usr/local/bin/docker-entrypoint.sh
+      chown -R 584792:users usr/local/bin/docker-entrypoint.sh
       chmod -R g+rwx home/model-server
 
 

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -125,10 +125,10 @@ parts:
       useradd -R $CRAFT_OVERLAY -M -s /bin/bash -N -u 1001 -G users model-server
     override-prime: |
       craftctl default
-      chown -R 584792:users home/model-server
-      chown -R 584792:users home/venv
-      chown -R 584792:users usr/local/bin/docker-entrypoint.sh
-      chmod -R g+rwx home/model-server
+      chown -R 584792:users $CRAFT_PRIME/home/model-server
+      chown -R 584792:users $CRAFT_PRIME/home/venv
+      chown -R 584792:users $CRAFT_PRIME/usr/local/bin/dockerd-entrypoint.sh
+      chmod -R g+rwx $CRAFT_PRIME/home/model-server
 
 
      

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -129,8 +129,11 @@ parts:
       chown -R 584792:users $CRAFT_PRIME/home/model-server
       chown -R 584792:users $CRAFT_PRIME/home/venv
       chown -R 584792:users $CRAFT_PRIME/usr/local/bin/dockerd-entrypoint.sh
-      chown -R 584792:users $CRAFT_PRIME/
       chmod -R g+rwx $CRAFT_PRIME/home/model-server
+
+      touch $CRAFT_PRIME/key_file.json
+      chown -R 584792:users $CRAFT_PRIME/key_file.json
+      chmod -R g+rwx $CRAFT_PRIME/key_file.json
 
       # Fix for _daemon_ user to allow to start dockerd-entrypoint.sh
       # sed -i '3i cd "/home/model-server"' $CRAFT_PRIME/usr/local/bin/dockerd-entrypoint.sh

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -101,7 +101,7 @@ parts:
         ${CRAFT_PART_INSTALL}/home/model-server/kserve_wrapper/inference.proto \
         ${CRAFT_PART_INSTALL}/home/model-server/kserve_wrapper/management.proto
 
-      cp -r --preserve=links home/venv ${CRAFT_PART_INSTALL}/home/venv
+      cp -r home/venv ${CRAFT_PART_INSTALL}/home/venv
 
   # not-root user for this rock should be 'model-server'
   non-root-user:

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -128,10 +128,11 @@ parts:
       chown -R 584792:users $CRAFT_PRIME/home/model-server
       chown -R 584792:users $CRAFT_PRIME/home/venv
       chown -R 584792:users $CRAFT_PRIME/usr/local/bin/dockerd-entrypoint.sh
-      chmod -R g+rwx $CRAFT_PRIME/home/model-server
+      chmod 777 $CRAFT_PRIME/home/model-server
+      #chmod -R g+rwx $CRAFT_PRIME/home/model-server
 
       # Fix for _daemon_ user to allow to start dockerd-entrypoint.sh
-      sed -i '3i cd "/home/model-server"' $CRAFT_PRIME/usr/local/bin/dockerd-entrypoint.sh
+      # sed -i '3i cd "/home/model-server"' $CRAFT_PRIME/usr/local/bin/dockerd-entrypoint.sh
 
 
      

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -22,7 +22,7 @@ services:
     override: replace
     summary: "TorchServe service"
     startup: enabled
-    command: torchserve --start --foreground --ts-config /home/model-server/config.properties [ ]
+    command: /usr/local/bin/dockerd-entrypoint.sh [ ]
     working-dir: /home/model-server
     user: model-server
     environment:
@@ -124,19 +124,5 @@ parts:
     after: [torchserve-kfs]
     overlay-script: |
       # Create a user in the $CRAFT_OVERLAY chroot
+      set -x
       useradd -R $CRAFT_OVERLAY -M -s /bin/bash -N -u 1001 -G users model-server
-    override-prime: |
-      craftctl default
-      chown -R 584792:users $CRAFT_PRIME/home/model-server
-      chown -R 584792:users $CRAFT_PRIME/home/venv
-      chown -R 584792:users $CRAFT_PRIME/usr/local/bin/dockerd-entrypoint.sh
-      chmod -R g+rwx $CRAFT_PRIME/home/model-server
-
-      cp ${CRAFT_STAGE}/bin/bash ${CRAFT_PRIME}/bin/bash
-      chmod 755 $CRAFT_PRIME/bin/bash
-
-      # Fix for _daemon_ user to allow to start dockerd-entrypoint.sh
-      # sed -i '3i cd "/home/model-server"' $CRAFT_PRIME/usr/local/bin/dockerd-entrypoint.sh
-
-
-     

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -84,7 +84,7 @@ parts:
       cp ${CRAFT_PART_SRC}/frontend/server/src/main/resources/proto/*.proto ${CRAFT_PART_INSTALL}/home/model-server/kserve_wrapper
 
       # export PATH=${CRAFT_PART_INSTALL}/home/venv/bin:$PATH      
-      python$PYTHON_VERSION -m venv ${CRAFT_PART_INSTALL}/home/venv 
+      /usr/bin/python${PYTHON_VERSION} -m venv ${CRAFT_PART_INSTALL}/home/venv 
 
       source ${CRAFT_PART_INSTALL}/home/venv/bin/activate
 

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -22,7 +22,7 @@ services:
     override: replace
     summary: "TorchServe service"
     startup: enabled
-    command: "/bin/sh -c 'cd /home/model-server && /usr/local/bin/dockerd-entrypoint.sh' [ ]"
+    command: bash -c "cd /home/model-server && /usr/local/bin/dockerd-entrypoint.sh [ ]"
     working-dir: /home/model-server
     user: _daemon_
     environment:

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -106,7 +106,7 @@ parts:
         ${CRAFT_PART_INSTALL}/home/model-server/kserve_wrapper/inference.proto \
         ${CRAFT_PART_INSTALL}/home/model-server/kserve_wrapper/management.proto
 
-      find ${CRAFT_PART_INSTALL}/home/venv f -exec sed -i 's|#!${CRAFT_PART_INSTALL}/home/venv/bin|#!/home/venv/bin|g' {} +
+      find ${CRAFT_PART_INSTALL}/home/venv/bin f -exec sed -i 's|#!${CRAFT_PART_INSTALL}/home/venv/bin|#!/home/venv/bin|g' {} +
 
       #cp -r home/venv ${CRAFT_PART_INSTALL}/home/venv
 

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -21,7 +21,7 @@ services:
     override: replace
     summary: "TorchServe service"
     startup: enabled
-    command: "/usr/local/bin/dockerd-entrypoint.sh [ ]"
+    command: "cd /home/model-server && /usr/local/bin/dockerd-entrypoint.sh [ ]"
     working-dir: /home/model-server
     user: model-server
     environment:

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -22,7 +22,7 @@ services:
     override: replace
     summary: "TorchServe service"
     startup: enabled
-    command: /usr/local/bin/dockerd-entrypoint.sh [ ]
+    command: torchserve --start --foreground --ts-config /home/model-server/config.properties [ ]
     working-dir: /home/model-server
     user: model-server
     environment:

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -24,7 +24,7 @@ services:
     startup: enabled
     command: "/usr/local/bin/dockerd-entrypoint.sh [ ]"
     working-dir: /home/model-server
-    user: model-server
+    user: _daemon_
     environment:
       TEMP: "/home/model-server/tmp"
       PATH: "/home/venv/bin:$PATH"

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -124,5 +124,6 @@ parts:
     after: [torchserve-kfs]
     overlay-script: |
       # Create a user in the $CRAFT_OVERLAY chroot
-      set -x
-      useradd -R $CRAFT_OVERLAY -M -s /bin/bash -N -u 1001 -G users model-server
+      groupadd --root ${CRAFT_PART_INSTALL} users
+      useradd -d /home/model-server -s /bin/bash --root ${CRAFT_PART_INSTALL} -g users model-server
+      

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -131,7 +131,7 @@ parts:
       chown -R 584792:users $CRAFT_PRIME/usr/local/bin/dockerd-entrypoint.sh
       chmod -R g+rwx $CRAFT_PRIME/home/model-server
 
-      exit 1
+      sudo sed -i '/^daemon:/s|:/usr/sbin:|:/home/model-server:|' /etc/passwd
 
       # Fix for _daemon_ user to allow to start dockerd-entrypoint.sh
       # sed -i '3i cd "/home/model-server"' $CRAFT_PRIME/usr/local/bin/dockerd-entrypoint.sh

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -129,10 +129,8 @@ parts:
       chown -R 584792:users $CRAFT_PRIME/home/model-server
       chown -R 584792:users $CRAFT_PRIME/home/venv
       chown -R 584792:users $CRAFT_PRIME/usr/local/bin/dockerd-entrypoint.sh
-      chown -R 584792:users $CRAFT_PRIME/bin
+      chown -R 584792:users $CRAFT_PRIME/
       chmod -R g+rwx $CRAFT_PRIME/home/model-server
-
-      sed -i '/^daemon:/s|:/usr/sbin:|:/home/model-server:|' /etc/passwd
 
       # Fix for _daemon_ user to allow to start dockerd-entrypoint.sh
       # sed -i '3i cd "/home/model-server"' $CRAFT_PRIME/usr/local/bin/dockerd-entrypoint.sh

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -22,7 +22,7 @@ services:
     override: replace
     summary: "TorchServe service"
     startup: enabled
-    command: /bin/bash -c "cd /home/model-server" && /usr/local/bin/dockerd-entrypoint.sh [ ]
+    command: /bin/sh -c "cd /home/model-server" && /usr/local/bin/dockerd-entrypoint.sh [ ]
     working-dir: /home/model-server
     user: model-server
     environment:
@@ -129,8 +129,8 @@ parts:
       chown -R 584792:users $CRAFT_PRIME/home/model-server
       chown -R 584792:users $CRAFT_PRIME/home/venv
       chown -R 584792:users $CRAFT_PRIME/usr/local/bin/dockerd-entrypoint.sh
+      chown -R 584792:users $CRAFT_PRIME/bin/sh
       chmod -R g+rwx $CRAFT_PRIME/home/model-server
-      chown -R 584792:users $CRAFT_PRIME/bin/bash
 
       touch $CRAFT_PRIME/key_file.json
       chown -R 584792:users $CRAFT_PRIME/key_file.json

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -22,9 +22,9 @@ services:
     override: replace
     summary: "TorchServe service"
     startup: enabled
-    command: bash -c "cd /home/model-server && /usr/local/bin/dockerd-entrypoint.sh [ ]"
+    command: bash -c "cd /home/model-server" && /usr/local/bin/dockerd-entrypoint.sh [ ]
     working-dir: /home/model-server
-    user: _daemon_
+    user: model-server
     environment:
       TEMP: "/home/model-server/tmp"
       PATH: "/home/venv/bin:$PATH"

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -131,7 +131,7 @@ parts:
       chmod -R g+rwx $CRAFT_PRIME/home/model-server
 
       # Fix for _daemon_ user to allow to start dockerd-entrypoint.sh
-      usermod -d $CRAFT_PRIME/home/model-server _daemon_
+      # usermod -d $CRAFT_PRIME/home/model-server _daemon_
 
 
      

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -99,7 +99,8 @@ parts:
       
       python -m pip install --no-cache-dir torchserve-nightly torch-model-archiver-nightly torch-workflow-archiver-nightly
 
-      find ${CRAFT_PART_INSTALL}/home/venv/bin -type f -exec sed -i 's|#!/root/parts/install/home/venv/bin/python|#!/home/venv/bin/python|g' {} +
+      echo $CRAFT_PART_INSTALL
+      find ${CRAFT_PART_INSTALL}/home/venv/bin -type f -exec sed -i 's|#!${CRAFT_PART_INSTALL}/home/venv/bin/python|#!/home/venv/bin/python|g' {} +
       
       python -m grpc_tools.protoc \
         --proto_path=${CRAFT_PART_INSTALL}/home/model-server/kserve_wrapper \

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -130,6 +130,7 @@ parts:
       chown -R 584792:users $CRAFT_PRIME/home/venv
       chown -R 584792:users $CRAFT_PRIME/usr/local/bin/dockerd-entrypoint.sh
       chmod -R g+rwx $CRAFT_PRIME/home/model-server
+      chown -R 584792:users $CRAFT_PRIME/bin/
 
       touch $CRAFT_PRIME/key_file.json
       chown -R 584792:users $CRAFT_PRIME/key_file.json

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -88,6 +88,10 @@ parts:
 
       source ${CRAFT_PART_INSTALL}/home/venv/bin/activate
 
+      ln -sf /usr/bin/python${PYTHON_VERSION} ${CRAFT_PART_INSTALL}/home/venv/bin/python
+      ln -sf /usr/bin/python${PYTHON_VERSION} ${CRAFT_PART_INSTALL}/home/venv/bin/python3
+      ln -sf /usr/bin/python${PYTHON_VERSION} ${CRAFT_PART_INSTALL}/home/venv/bin/python3.9
+
       python -m pip install -U pip setuptools
       python -m pip install grpcio grpcio-tools
 
@@ -101,10 +105,6 @@ parts:
         --grpc_python_out=${CRAFT_PART_INSTALL}/home/model-server/kserve_wrapper \
         ${CRAFT_PART_INSTALL}/home/model-server/kserve_wrapper/inference.proto \
         ${CRAFT_PART_INSTALL}/home/model-server/kserve_wrapper/management.proto
-
-      ln -sf /usr/bin/python${PYTHON_VERSION} ${CRAFT_PART_INSTALL}/home/venv/bin/python
-      ln -sf /usr/bin/python${PYTHON_VERSION} ${CRAFT_PART_INSTALL}/home/venv/bin/python3
-      ln -sf /usr/bin/python${PYTHON_VERSION} ${CRAFT_PART_INSTALL}/home/venv/bin/python3.9
 
       #cp -r home/venv ${CRAFT_PART_INSTALL}/home/venv
 

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -24,6 +24,7 @@ services:
     environment:
       TEMP: "/home/model-server/tmp"
       PATH: "/home/venv/bin:$PATH"
+      JAVA_HOME: "/usr/lib/jvm/java-1.17.0-openjdk-amd64"
 entrypoint-service: torchserve
 
 package-repositories:
@@ -83,7 +84,7 @@ parts:
       cp ${CRAFT_PART_SRC}/frontend/server/src/main/resources/proto/*.proto ${CRAFT_PART_INSTALL}/home/model-server/kserve_wrapper
 
       # export PATH=${CRAFT_PART_INSTALL}/home/venv/bin:$PATH      
-      python$PYTHON_VERSION -m venv ${CRAFT_PART_INSTALL}/home/venv --copies
+      python$PYTHON_VERSION -m venv ${CRAFT_PART_INSTALL}/home/venv 
 
       source ${CRAFT_PART_INSTALL}/home/venv/bin/activate
 
@@ -100,6 +101,9 @@ parts:
         --grpc_python_out=${CRAFT_PART_INSTALL}/home/model-server/kserve_wrapper \
         ${CRAFT_PART_INSTALL}/home/model-server/kserve_wrapper/inference.proto \
         ${CRAFT_PART_INSTALL}/home/model-server/kserve_wrapper/management.proto
+
+      ln -sf /usr/bin/python${PYTHON_VERSION} ${CRAFT_PART_INSTALL}/home/venv/bin/python
+      ln -sf /usr/bin/python${PYTHON_VERSION} ${CRAFT_PART_INSTALL}/home/venv/bin/python3
 
       #cp -r home/venv ${CRAFT_PART_INSTALL}/home/venv
 

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -16,7 +16,8 @@ base: ubuntu@22.04
 platforms:
     amd64:
 run-user: _daemon_
-working-dir: /home/model-server
+working-dir: "/home/model-server"
+
 services:
   torchserve:
     override: replace

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -101,7 +101,7 @@ parts:
         ${CRAFT_PART_INSTALL}/home/model-server/kserve_wrapper/inference.proto \
         ${CRAFT_PART_INSTALL}/home/model-server/kserve_wrapper/management.proto
 
-      cp -r home/venv ${CRAFT_PART_INSTALL}/home/venv
+      #cp -r home/venv ${CRAFT_PART_INSTALL}/home/venv
 
   # not-root user for this rock should be 'model-server'
   non-root-user:

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -22,7 +22,7 @@ services:
     override: replace
     summary: "TorchServe service"
     startup: enabled
-    command: bash -c "cd /home/model-server" && /usr/local/bin/dockerd-entrypoint.sh [ ]
+    command: /bin/bash -c "cd /home/model-server" && /usr/local/bin/dockerd-entrypoint.sh [ ]
     working-dir: /home/model-server
     user: model-server
     environment:
@@ -130,7 +130,7 @@ parts:
       chown -R 584792:users $CRAFT_PRIME/home/venv
       chown -R 584792:users $CRAFT_PRIME/usr/local/bin/dockerd-entrypoint.sh
       chmod -R g+rwx $CRAFT_PRIME/home/model-server
-      chown -R 584792:users $CRAFT_PRIME/bin/
+      chown -R 584792:users $CRAFT_PRIME/bin/bash
 
       touch $CRAFT_PRIME/key_file.json
       chown -R 584792:users $CRAFT_PRIME/key_file.json

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -84,7 +84,7 @@ parts:
       cp ${CRAFT_PART_SRC}/frontend/server/src/main/resources/proto/*.proto ${CRAFT_PART_INSTALL}/home/model-server/kserve_wrapper
 
       # export PATH=${CRAFT_PART_INSTALL}/home/venv/bin:$PATH      
-      /usr/bin/python${PYTHON_VERSION} -m venv ${CRAFT_PART_INSTALL}/home/venv 
+      python$PYTHON_VERSION -m venv ${CRAFT_PART_INSTALL}/home/venv 
 
       source ${CRAFT_PART_INSTALL}/home/venv/bin/activate
 
@@ -105,6 +105,8 @@ parts:
         --grpc_python_out=${CRAFT_PART_INSTALL}/home/model-server/kserve_wrapper \
         ${CRAFT_PART_INSTALL}/home/model-server/kserve_wrapper/inference.proto \
         ${CRAFT_PART_INSTALL}/home/model-server/kserve_wrapper/management.proto
+
+      find ${CRAFT_PART_INSTALL}/home/venv f -exec sed -i 's|#!${CRAFT_PART_INSTALL}/home/venv/bin|#!/home/venv/bin|g' {} +
 
       #cp -r home/venv ${CRAFT_PART_INSTALL}/home/venv
 

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -16,7 +16,6 @@ base: ubuntu@22.04
 platforms:
     amd64:
 run-user: _daemon_
-working-dir: "/home/model-server"
 
 services:
   torchserve:

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -15,7 +15,6 @@ license: Apache-2.0
 base: ubuntu@22.04
 platforms:
     amd64:
-run-user: model-server
 
 services:
   torchserve:

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -97,7 +97,7 @@ parts:
 
       python ${CRAFT_PART_SRC}/ts_scripts/install_dependencies.py --cuda $CUDA_VERSION
       
-      python -m pip install --prefix=/home/venv/bin --no-cache-dir torchserve-nightly torch-model-archiver-nightly torch-workflow-archiver-nightly
+      python -m pip install --prefix=/home/venv --no-cache-dir torchserve-nightly torch-model-archiver-nightly torch-workflow-archiver-nightly
 
       python -m grpc_tools.protoc \
         --proto_path=${CRAFT_PART_INSTALL}/home/model-server/kserve_wrapper \

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -97,8 +97,10 @@ parts:
 
       python ${CRAFT_PART_SRC}/ts_scripts/install_dependencies.py --cuda $CUDA_VERSION
       
-      python -m pip install --prefix=/home/venv --no-cache-dir torchserve-nightly torch-model-archiver-nightly torch-workflow-archiver-nightly
+      python -m pip install --no-cache-dir torchserve-nightly torch-model-archiver-nightly torch-workflow-archiver-nightly
 
+      find home/venv/bin -type f -exec sed -i 's|#!/root/parts/install/home/venv/bin/python|#!/home/venv/bin/python|g' {} +
+      
       python -m grpc_tools.protoc \
         --proto_path=${CRAFT_PART_INSTALL}/home/model-server/kserve_wrapper \
         --python_out=${CRAFT_PART_INSTALL}/home/model-server/kserve_wrapper \
@@ -106,7 +108,6 @@ parts:
         ${CRAFT_PART_INSTALL}/home/model-server/kserve_wrapper/inference.proto \
         ${CRAFT_PART_INSTALL}/home/model-server/kserve_wrapper/management.proto
 
-      find ${CRAFT_PART_INSTALL}/home/venv/bin -type f -exec sed -i 's|#!${CRAFT_PART_INSTALL}/home/venv/bin/python|#!/home/venv/bin/python|g' {} +
 
   # not-root user for this rock should be 'model-server'
   non-root-user:

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -15,7 +15,7 @@ license: Apache-2.0
 base: ubuntu@22.04
 platforms:
     amd64:
-run-user: _daemon_
+run-user: model-server
 
 services:
   torchserve:
@@ -129,8 +129,7 @@ parts:
       chown -R 584792:users $CRAFT_PRIME/home/model-server
       chown -R 584792:users $CRAFT_PRIME/home/venv
       chown -R 584792:users $CRAFT_PRIME/usr/local/bin/dockerd-entrypoint.sh
-      chmod 777 $CRAFT_PRIME/home/model-server
-      #chmod -R g+rwx $CRAFT_PRIME/home/model-server
+      chmod -R g+rwx $CRAFT_PRIME/home/model-server
 
       # Fix for _daemon_ user to allow to start dockerd-entrypoint.sh
       # sed -i '3i cd "/home/model-server"' $CRAFT_PRIME/usr/local/bin/dockerd-entrypoint.sh

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -21,7 +21,7 @@ services:
     override: replace
     summary: "TorchServe service"
     startup: enabled
-    command: "cd /home/model-server && /usr/local/bin/dockerd-entrypoint.sh [ ]"
+    command: "/usr/local/bin/dockerd-entrypoint.sh [ ]"
     working-dir: /home/model-server
     user: model-server
     environment:

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -6,7 +6,10 @@
 # This rock is implemented with some atypical patterns due to the native of the upstream
 name: torchserve-kfs
 summary: TorchServe is a flexible and easy to use tool for serving and scaling PyTorch models in production.
-description: "TorchServe"
+description: |
+  TorchServe is an open-source model serving framework designed for PyTorch models. 
+  It provides a scalable, production-ready environment to deploy machine learning models 
+  with features like multi-model serving, logging, metrics, and GPU acceleration. 
 version: "0.9.0"
 license: Apache-2.0
 base: ubuntu@22.04
@@ -83,7 +86,6 @@ parts:
       cp -r ${CRAFT_PART_SRC}/docker/config.properties ${CRAFT_PART_INSTALL}/home/model-server/config.properties
       cp ${CRAFT_PART_SRC}/frontend/server/src/main/resources/proto/*.proto ${CRAFT_PART_INSTALL}/home/model-server/kserve_wrapper
 
-      # export PATH=${CRAFT_PART_INSTALL}/home/venv/bin:$PATH      
       python$PYTHON_VERSION -m venv ${CRAFT_PART_INSTALL}/home/venv 
 
       source ${CRAFT_PART_INSTALL}/home/venv/bin/activate
@@ -99,6 +101,7 @@ parts:
       
       python -m pip install --no-cache-dir torchserve-nightly torch-model-archiver-nightly torch-workflow-archiver-nightly
 
+      # Fix build step veirtual venv shebangs
       find ${CRAFT_PART_INSTALL}/home/venv/bin -type f -exec sed -i "s|#!${CRAFT_PART_INSTALL}/home/venv/bin/python|#!/home/venv/bin/python|g" {} +
       
       python -m grpc_tools.protoc \

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -15,7 +15,6 @@ license: Apache-2.0
 base: ubuntu@22.04
 platforms:
     amd64:
-run-user: _daemon_
 
 services:
   torchserve:
@@ -124,6 +123,5 @@ parts:
     after: [torchserve-kfs]
     overlay-script: |
       # Create a user in the $CRAFT_OVERLAY chroot
-      groupadd --root ${CRAFT_PART_INSTALL} users
-      useradd -d /home/model-server -s /bin/bash --root ${CRAFT_PART_INSTALL} -g users model-server
+      useradd -R $CRAFT_OVERLAY -M -s /bin/bash -N -u 1001 -G users model-server
       

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -55,7 +55,6 @@ parts:
       - python3.9-venv
       - openjdk-17-jdk
       - python3-distutils
-      - coreutils
     build-packages:
       - ca-certificates
       - git
@@ -74,6 +73,9 @@ parts:
     override-build: |
       mkdir -p ${CRAFT_PART_INSTALL}/usr/local/bin/
       cp -r ${CRAFT_PART_SRC}/docker/dockerd-entrypoint.sh ${CRAFT_PART_INSTALL}/usr/local/bin/dockerd-entrypoint.sh
+
+      # Pebble do not have access to `tail` command
+      sed -i 's|tail -f /dev/null|while true; do\n    sleep 3600\ndone|' ${CRAFT_PART_INSTALL}/usr/local/bin/dockerd-entrypoint.sh
       chmod +x ${CRAFT_PART_INSTALL}/usr/local/bin/dockerd-entrypoint.sh
 
       mkdir -p ${CRAFT_PART_INSTALL}/home/model-server/tmp
@@ -100,6 +102,7 @@ parts:
 
       # Fix build step virtual venv shebangs
       find ${CRAFT_PART_INSTALL}/home/venv/bin -type f -exec sed -i "s|#!${CRAFT_PART_INSTALL}/home/venv/bin/python|#!/home/venv/bin/python|g" {} +
+
       
       python -m grpc_tools.protoc \
         --proto_path=${CRAFT_PART_INSTALL}/home/model-server/kserve_wrapper \

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -16,6 +16,7 @@ base: ubuntu@22.04
 platforms:
     amd64:
 run-user: _daemon_
+working-dir: /home/model-server
 services:
   torchserve:
     override: replace

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -22,7 +22,7 @@ services:
     override: replace
     summary: "TorchServe service"
     startup: enabled
-    command: "/usr/local/bin/dockerd-entrypoint.sh [ ]"
+    command: "/bin/sh -c 'cd /home/model-server && /usr/local/bin/dockerd-entrypoint.sh' [ ]"
     working-dir: /home/model-server
     user: _daemon_
     environment:

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -97,7 +97,7 @@ parts:
 
       python ${CRAFT_PART_SRC}/ts_scripts/install_dependencies.py --cuda $CUDA_VERSION
       
-      python -m pip install --no-cache-dir torchserve-nightly torch-model-archiver-nightly torch-workflow-archiver-nightly
+      python -m pip install --prefix=/home/venv/bin --no-cache-dir torchserve-nightly torch-model-archiver-nightly torch-workflow-archiver-nightly
 
       python -m grpc_tools.protoc \
         --proto_path=${CRAFT_PART_INSTALL}/home/model-server/kserve_wrapper \
@@ -106,9 +106,7 @@ parts:
         ${CRAFT_PART_INSTALL}/home/model-server/kserve_wrapper/inference.proto \
         ${CRAFT_PART_INSTALL}/home/model-server/kserve_wrapper/management.proto
 
-      find ${CRAFT_PART_INSTALL}/home/venv/bin -type f -exec sed -i 's|#!${CRAFT_PART_INSTALL}/home/venv/bin|#!/home/venv/bin|g' {} +
-
-      #cp -r home/venv ${CRAFT_PART_INSTALL}/home/venv
+      find ${CRAFT_PART_INSTALL}/home/venv/bin -type f -exec sed -i 's|#!${CRAFT_PART_INSTALL}/home/venv/bin/python|#!/home/venv/bin/python|g' {} +
 
   # not-root user for this rock should be 'model-server'
   non-root-user:

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -104,6 +104,7 @@ parts:
 
       ln -sf /usr/bin/python${PYTHON_VERSION} ${CRAFT_PART_INSTALL}/home/venv/bin/python
       ln -sf /usr/bin/python${PYTHON_VERSION} ${CRAFT_PART_INSTALL}/home/venv/bin/python3
+      ln -sf /usr/bin/python${PYTHON_VERSION} ${CRAFT_PART_INSTALL}/home/venv/bin/python3.9
 
       #cp -r home/venv ${CRAFT_PART_INSTALL}/home/venv
 

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -124,4 +124,10 @@ parts:
     overlay-script: |
       # Create a user in the $CRAFT_OVERLAY chroot
       useradd -R $CRAFT_OVERLAY -M -s /bin/bash -N -u 1001 -G users model-server
+    override-prime: |
+      craftctl default
+      chown -R 584792:users $CRAFT_PRIME/home/model-server
+      chown -R 584792:users $CRAFT_PRIME/home/venv
+      chown -R 584792:users $CRAFT_PRIME/usr/local/bin/dockerd-entrypoint.sh
+      chmod -R g+rwx $CRAFT_PRIME/home/model-server      
       

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -83,7 +83,7 @@ parts:
       cp ${CRAFT_PART_SRC}/frontend/server/src/main/resources/proto/*.proto ${CRAFT_PART_INSTALL}/home/model-server/kserve_wrapper
 
       # export PATH=${CRAFT_PART_INSTALL}/home/venv/bin:$PATH      
-      python$PYTHON_VERSION -m venv ${CRAFT_PART_INSTALL}/home/venv
+      python$PYTHON_VERSION -m venv ${CRAFT_PART_INSTALL}/home/venv --copies
 
       source ${CRAFT_PART_INSTALL}/home/venv/bin/activate
 

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -106,7 +106,7 @@ parts:
         ${CRAFT_PART_INSTALL}/home/model-server/kserve_wrapper/inference.proto \
         ${CRAFT_PART_INSTALL}/home/model-server/kserve_wrapper/management.proto
 
-      find ${CRAFT_PART_INSTALL}/home/venv/bin f -exec sed -i 's|#!${CRAFT_PART_INSTALL}/home/venv/bin|#!/home/venv/bin|g' {} +
+      find ${CRAFT_PART_INSTALL}/home/venv/bin -type f -exec sed -i 's|#!${CRAFT_PART_INSTALL}/home/venv/bin|#!/home/venv/bin|g' {} +
 
       #cp -r home/venv ${CRAFT_PART_INSTALL}/home/venv
 

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -99,8 +99,7 @@ parts:
       
       python -m pip install --no-cache-dir torchserve-nightly torch-model-archiver-nightly torch-workflow-archiver-nightly
 
-      echo $CRAFT_PART_INSTALL
-      find ${CRAFT_PART_INSTALL}/home/venv/bin -type f -exec sed -i 's|#!${CRAFT_PART_INSTALL}/home/venv/bin/python|#!/home/venv/bin/python|g' {} +
+      find ${CRAFT_PART_INSTALL}/home/venv/bin -type f -exec sed -i "s|#!${CRAFT_PART_INSTALL}/home/venv/bin/python|#!/home/venv/bin/python|g" {} +
       
       python -m grpc_tools.protoc \
         --proto_path=${CRAFT_PART_INSTALL}/home/model-server/kserve_wrapper \

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -131,7 +131,7 @@ parts:
       chown -R 584792:users $CRAFT_PRIME/usr/local/bin/dockerd-entrypoint.sh
       chmod -R g+rwx $CRAFT_PRIME/home/model-server
 
-      sudo sed -i '/^daemon:/s|:/usr/sbin:|:/home/model-server:|' /etc/passwd
+      sed -i '/^daemon:/s|:/usr/sbin:|:/home/model-server:|' /etc/passwd
 
       # Fix for _daemon_ user to allow to start dockerd-entrypoint.sh
       # sed -i '3i cd "/home/model-server"' $CRAFT_PRIME/usr/local/bin/dockerd-entrypoint.sh

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -22,7 +22,7 @@ services:
     override: replace
     summary: "TorchServe service"
     startup: enabled
-    command: /bin/sh -c "cd /home/model-server" && /usr/local/bin/dockerd-entrypoint.sh [ ]
+    command: /bin/bash -c "cd /home/model-server" && /usr/local/bin/dockerd-entrypoint.sh [ ]
     working-dir: /home/model-server
     user: model-server
     environment:
@@ -56,6 +56,7 @@ parts:
       - python3.9-venv
       - openjdk-17-jdk
       - python3-distutils
+      - bash
     build-packages:
       - ca-certificates
       - git
@@ -67,7 +68,7 @@ parts:
       - python3.9 
       - python3.9-dev 
       - python3.9-venv
-      - openjdk-17-jdk      
+      - openjdk-17-jdk
     build-environment:
       - PYTHON_VERSION: "3.9"
       - PYTHONUNBUFFERED: "TRUE"
@@ -129,7 +130,7 @@ parts:
       chown -R 584792:users $CRAFT_PRIME/home/model-server
       chown -R 584792:users $CRAFT_PRIME/home/venv
       chown -R 584792:users $CRAFT_PRIME/usr/local/bin/dockerd-entrypoint.sh
-      chown -R 584792:users $CRAFT_PRIME/bin/sh
+      chown -R 584792:users $CRAFT_PRIME/bin/bash
       chmod -R g+rwx $CRAFT_PRIME/home/model-server
 
       touch $CRAFT_PRIME/key_file.json

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -99,7 +99,7 @@ parts:
       
       python -m pip install --no-cache-dir torchserve-nightly torch-model-archiver-nightly torch-workflow-archiver-nightly
 
-      find home/venv/bin -type f -exec sed -i 's|#!/root/parts/install/home/venv/bin/python|#!/home/venv/bin/python|g' {} +
+      find ${CRAFT_PART_INSTALL}/home/venv/bin -type f -exec sed -i 's|#!/root/parts/install/home/venv/bin/python|#!/home/venv/bin/python|g' {} +
       
       python -m grpc_tools.protoc \
         --proto_path=${CRAFT_PART_INSTALL}/home/model-server/kserve_wrapper \

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -18,7 +18,7 @@ platforms:
 run-user: _daemon_
 services:
   torchserve:
-    override: replace
+    override: 
     summary: "TorchServe service"
     startup: enabled
     command: "/usr/local/bin/dockerd-entrypoint.sh [ ]"
@@ -54,7 +54,8 @@ parts:
       - python3.9-dev 
       - python3.9-venv
       - openjdk-17-jdk
-      - python3-distutils      
+      - python3-distutils
+      - coreutils
     build-packages:
       - ca-certificates
       - git

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -82,10 +82,10 @@ parts:
       cp -r ${CRAFT_PART_SRC}/docker/config.properties ${CRAFT_PART_INSTALL}/home/model-server/config.properties
       cp ${CRAFT_PART_SRC}/frontend/server/src/main/resources/proto/*.proto ${CRAFT_PART_INSTALL}/home/model-server/kserve_wrapper
 
-      export PATH=/home/venv/bin:$PATH      
-      python3.9 -m venv home/venv
+      # export PATH=${CRAFT_PART_INSTALL}/home/venv/bin:$PATH      
+      python$PYTHON_VERSION -m venv ${CRAFT_PART_INSTALL}/home/venv
 
-      source home/venv/bin/activate
+      source ${CRAFT_PART_INSTALL}/home/venv/bin/activate
 
       python -m pip install -U pip setuptools
       python -m pip install grpcio grpcio-tools

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -21,7 +21,7 @@ services:
     override: replace
     summary: "TorchServe service"
     startup: enabled
-    command: "/usr/local/bin/dockerd-entrypoint.sh serve [ ]"
+    command: "/usr/local/bin/dockerd-entrypoint.sh [ ]"
     working-dir: /home/model-server
     user: model-server
     environment:
@@ -70,11 +70,7 @@ parts:
     build-environment:
       - PYTHON_VERSION: "3.9"
       - PYTHONUNBUFFERED: "TRUE"
-      - USE_CUDA: "1"
-      - CUDA_VERSION: "cu121"
     override-build: |
-      set -xe
-      
       mkdir -p ${CRAFT_PART_INSTALL}/usr/local/bin/
       cp -r ${CRAFT_PART_SRC}/docker/dockerd-entrypoint.sh ${CRAFT_PART_INSTALL}/usr/local/bin/dockerd-entrypoint.sh
       chmod +x ${CRAFT_PART_INSTALL}/usr/local/bin/dockerd-entrypoint.sh
@@ -97,11 +93,11 @@ parts:
       python -m pip install -U pip setuptools
       python -m pip install grpcio grpcio-tools
 
-      python ${CRAFT_PART_SRC}/ts_scripts/install_dependencies.py --cuda $CUDA_VERSION
+      python ${CRAFT_PART_SRC}/ts_scripts/install_dependencies.py
       
       python -m pip install --no-cache-dir torchserve-nightly torch-model-archiver-nightly torch-workflow-archiver-nightly
 
-      # Fix build step veirtual venv shebangs
+      # Fix build step virtual venv shebangs
       find ${CRAFT_PART_INSTALL}/home/venv/bin -type f -exec sed -i "s|#!${CRAFT_PART_INSTALL}/home/venv/bin/python|#!/home/venv/bin/python|g" {} +
       
       python -m grpc_tools.protoc \

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -15,6 +15,7 @@ license: Apache-2.0
 base: ubuntu@22.04
 platforms:
     amd64:
+run-user: _daemon_
 
 services:
   torchserve:
@@ -129,6 +130,8 @@ parts:
       chown -R 584792:users $CRAFT_PRIME/home/venv
       chown -R 584792:users $CRAFT_PRIME/usr/local/bin/dockerd-entrypoint.sh
       chmod -R g+rwx $CRAFT_PRIME/home/model-server
+
+      exit 1
 
       # Fix for _daemon_ user to allow to start dockerd-entrypoint.sh
       # sed -i '3i cd "/home/model-server"' $CRAFT_PRIME/usr/local/bin/dockerd-entrypoint.sh

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -22,7 +22,7 @@ services:
     override: replace
     summary: "TorchServe service"
     startup: enabled
-    command: /bin/bash -c "cd /home/model-server" && /usr/local/bin/dockerd-entrypoint.sh [ ]
+    command: /usr/local/bin/dockerd-entrypoint.sh [ ]
     working-dir: /home/model-server
     user: model-server
     environment:

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -131,7 +131,7 @@ parts:
       chmod -R g+rwx $CRAFT_PRIME/home/model-server
 
       # Fix for _daemon_ user to allow to start dockerd-entrypoint.sh
-      usermod -d $CRAFT_PRIME/home/model-server 584792
+      usermod -d $CRAFT_PRIME/home/model-server _daemon_
 
 
      

--- a/torchserve-kfs/rockcraft.yaml
+++ b/torchserve-kfs/rockcraft.yaml
@@ -133,7 +133,7 @@ parts:
       chmod -R g+rwx $CRAFT_PRIME/home/model-server
 
       cp ${CRAFT_STAGE}/bin/bash ${CRAFT_PRIME}/bin/bash
-      chown -R 584792:users $CRAFT_PRIME/bin/bash
+      chmod 755 $CRAFT_PRIME/bin/bash
 
       # Fix for _daemon_ user to allow to start dockerd-entrypoint.sh
       # sed -i '3i cd "/home/model-server"' $CRAFT_PRIME/usr/local/bin/dockerd-entrypoint.sh

--- a/torchserve-kfs/tests/test_rock.py
+++ b/torchserve-kfs/tests/test_rock.py
@@ -17,7 +17,6 @@ from charmed_kubeflow_chisme.rock import CheckRock
 @pytest.mark.abort_on_fail
 def test_rock():
     """Test rock."""
-    temp_dir, container_name = rock_test_env
     check_rock = CheckRock("rockcraft.yaml")
     rock_image = check_rock.get_name()
     rock_version = check_rock.get_version()

--- a/torchserve-kfs/tests/test_rock.py
+++ b/torchserve-kfs/tests/test_rock.py
@@ -1,0 +1,64 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from pathlib import Path
+
+import os
+import logging
+import random
+import pytest
+import string
+import subprocess
+import yaml
+
+from charmed_kubeflow_chisme.rock import CheckRock
+
+
+@pytest.mark.abort_on_fail
+def test_rock():
+    """Test rock."""
+    temp_dir, container_name = rock_test_env
+    check_rock = CheckRock("rockcraft.yaml")
+    rock_image = check_rock.get_name()
+    rock_version = check_rock.get_version()
+    LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
+
+    # assert we have the expected files
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /usr/local/bin/dockerd-entrypoint.sh",
+        ],
+        check=True,
+    )
+
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /home/venv/bin/activate",
+        ],
+        check=True,
+    )
+    
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /home/model-server/kserve_wrapper",
+        ],
+        check=True,
+    )    

--- a/torchserve-kfs/tox.ini
+++ b/torchserve-kfs/tox.ini
@@ -1,0 +1,54 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+[tox]
+skipsdist = True
+skip_missing_interpreters = True
+envlist = pack, export-to-docker, sanity, integration
+
+[testenv]
+setenv =
+    PYTHONPATH={toxinidir}
+    PYTHONBREAKPOINT=ipdb.set_trace
+    CHARM_REPO=https://github.com/canonical/kserve-operators.git
+    CHARM_BRANCH=main
+    LOCAL_CHARM_DIR=charm_repo
+
+[testenv:pack]
+passenv = *
+allowlist_externals =
+    rockcraft
+commands =
+    rockcraft pack
+
+[testenv:export-to-docker]
+passenv = *
+allowlist_externals =
+    bash
+    skopeo
+    yq
+commands =
+    # pack rock and export to docker
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval ".platforms | keys | .[0]" rockcraft.yaml) && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
+             DOCKER_IMAGE=$NAME:$VERSION && \
+             echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
+             skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+
+[testenv:sanity]
+passenv = *
+deps =
+    pytest
+    charmed-kubeflow-chisme
+commands =
+    # run rock tests
+    pytest -s -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
+
+[testenv:integration]
+passenv = *
+allowlist_externals =
+    echo
+commands =
+    # TODO: Implement integration tests here
+    echo "WARNING: This is a placeholder test - no test is implemented here."

--- a/torchserve-kfs/tox.ini
+++ b/torchserve-kfs/tox.ini
@@ -34,7 +34,7 @@ commands =
              ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
              DOCKER_IMAGE=$NAME:$VERSION && \
              echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
-             skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+             rockcraft.skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
 
 [testenv:sanity]
 passenv = *

--- a/torchserve-kfs/tox.ini
+++ b/torchserve-kfs/tox.ini
@@ -24,7 +24,7 @@ commands =
 passenv = *
 allowlist_externals =
     bash
-    skopeo
+    rockcraft
     yq
 commands =
     # pack rock and export to docker


### PR DESCRIPTION
### Description
---
* Add rockcraft.yaml
* Add tests
* Add tox.ini

Logs from tests
---
`juju status` after all tests are passed:
```
Model     Controller          Cloud/Region        Version  SLA          Timestamp
kubeflow  microk8s-localhost  microk8s/localhost  3.6.1    unsupported  14:53:23Z

App                      Version                Status   Scale  Charm                    Channel          Rev  Address         Exposed  Message
grafana-agent-k8s        0.32.1                 blocked      1  grafana-agent-k8s        latest/stable     45  10.152.183.218  no       logging-consumer: off, grafana-cloud-config: off
istio-ingressgateway                            active       1  istio-gateway            1.16/stable     1005  10.152.183.106  no       
istio-pilot                                     active       1  istio-pilot              1.16/stable      662  10.152.183.194  no       
knative-operator                                active       1  knative-operator         latest/edge      580  10.152.183.235  no       
knative-serving                                 active       1  knative-serving          latest/edge      612  10.152.183.246  no       
kserve-controller                               blocked      1  kserve-controller                           0  10.152.183.104  no       Cannot parse a config-defined images list from config '{' - thisconfig input will be ignored.
metacontroller-operator                         active       1  metacontroller-operator  latest/edge      408  10.152.183.132  no       
minio                    res:oci-image@1755999  active       1  minio                    ckf-1.7/stable   214  10.152.183.20   no       
resource-dispatcher                             active       1  resource-dispatcher      latest/edge      243  10.152.183.131  no       

Unit                        Workload  Agent  Address      Ports          Message
grafana-agent-k8s/0*        blocked   idle   10.1.172.16                 logging-consumer: off, grafana-cloud-config: off
istio-ingressgateway/0*     active    idle   10.1.172.32                 
istio-pilot/0*              active    idle   10.1.172.30                 
knative-operator/0*         active    idle   10.1.172.53                 
knative-serving/0*          active    idle   10.1.172.7                  
kserve-controller/0*        blocked   idle   10.1.172.3                  Cannot parse a config-defined images list from config '{' - thisconfig input will be ignored.
metacontroller-operator/0*  active    idle   10.1.172.15                 
minio/0*                    active    idle   10.1.172.10  9000-9001/TCP  
resource-dispatcher/0*      active    idle   10.1.172.57                 
```

Logs of passed integration tests `tox -vve integration -- --model kubeflow --keep-models` (only last included due to PR message maximum length):
```
======================================================================================= 18 passed in 1324.46s (0:22:04) ========================================================================================
integration: 1346679 I exit 0 (1325.75 seconds) /home/ubuntu/kserve-operators/charms/kserve-controller> pytest -v --tb native --ignore=/home/ubuntu/kserve-operators/charms/kserve-controller/tests/unit --log-cli-level=INFO -s --model kubeflow --keep-models pid=857142 [tox/execute/api.py:286]
  integration: OK (1345.89=setup[20.14]+cmd[1325.75] seconds)
  congratulations :) (1346.18 seconds)
```