### PR TITLE
feat: update `agent` rock to v1.14.1

### DIFF
--- a/agent/rockcraft.yaml
+++ b/agent/rockcraft.yaml
@@ -1,8 +1,8 @@
-# Based on https://github.com/kserve/kserve/blob/v0.13.0/agent.Dockerfile
+# Based on https://github.com/kserve/kserve/blob/v0.14.1/agent.Dockerfile
 name: kserve-agent
 summary: KServe agent
 description: "KServe model agent"
-version: "0.13.0"
+version: "0.14.1"
 license: Apache-2.0
 base: ubuntu@22.04
 platforms:
@@ -30,9 +30,9 @@ parts:
     plugin: go
     source: https://github.com/kserve/kserve
     source-type: git
-    source-tag: v0.13.0
+    source-tag: v0.14.1
     build-snaps:
-      - go/1.21/stable
+      - go/1.22/stable
     build-environment:
       - CGO_ENABLED: 0
       - GOOS: linux


### PR DESCRIPTION
Closes: https://warthogs.atlassian.net/browse/KF-6810

Updates: 
- new version of go

Steps to test 
```
rockcraft clean && rockcraft pack --verbosity=trace --debug
sudo rockcraft.skopeo --insecure-policy copy oci-archive:kserve-agent_0.14.1_amd64.rock docker-daemon:misohu/kserve-agent:0.14.1
docker run <image>
docker exec -ti <container> bash
pebble logs 

# Expected output
2025-02-05T08:08:19.549Z [kserve-agent] required key SERVING_READINESS_PROBE missing value
````
