### PR TITLE
feat: update `controller` rock to v1.14.1

### DIFF
--- a/controller/rockcraft.yaml
+++ b/controller/rockcraft.yaml
@@ -1,8 +1,8 @@
-# Based on https://github.com/kserve/kserve/blob/v0.13.0/Dockerfile
+# Based on https://github.com/kserve/kserve/blob/v0.14.1/Dockerfile
 name: kserve-controller
 summary: KServe controller
 description: "KServe controller manager"
-version: "0.13.0"
+version: "0.14.1"
 license: Apache-2.0
 base: ubuntu@22.04
 platforms:
@@ -29,9 +29,9 @@ parts:
     plugin: go
     source: https://github.com/kserve/kserve
     source-type: git
-    source-tag: v0.13.0
+    source-tag: v0.14.1
     build-snaps:
-      - go/1.21/stable
+      - go/1.22/stable
     build-environment:
       - CGO_ENABLED: 0
       - GOOS: linux


### PR DESCRIPTION
Closes: https://warthogs.atlassian.net/browse/KF-6810

Updates: 
- new version of go

Steps to test 
```
rockcraft clean && rockcraft pack --verbosity=trace --debug
sudo rockcraft.skopeo --insecure-policy copy oci-archive:kserve-controller_0.14.1_amd64.rock docker-daemon:misohu/kserve-controller:0.14.1
docker run <image>
docker exec -ti <container> bash
pebble logs 

# Expected output
025-02-05T08:15:19.059Z [kserve-controller] {"level":"info","ts":"2025-02-05T08:15:19Z","logger":"setup","msg":"Setting up client for manager"}
2025-02-05T08:15:19.059Z [kserve-controller] {"level":"error","ts":"2025-02-05T08:15:19Z","logger":"controller-runtime.client.config","msg":"unable to load in-cluster config","error":"unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined","stacktrace":"sigs.k8s.io/controller-runtime/pkg/client/config.loadConfig.func1\n\t/root/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.5/pkg/client/config/config.go:133\nsigs.k8s.io/controller-runtime/pkg/client/config.loadConfig\n\t/root/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.5/pkg/client/config/config.go:155\nsigs.k8s.io/controller-runtime/pkg/client/config.GetConfigWithContext\n\t/root/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.5/pkg/client/config/config.go:97\nsigs.k8s.io/controller-runtime/pkg/client/config.GetConfig\n\t/root/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.5/pkg/client/config/config.go:77\nmain.main\n\t/root/parts/controller/build/cmd/manager/main.go:111\nruntime.main\n\t/snap/go/10807/src/runtime/proc.go:271"}
2025-02-05T08:15:19.059Z [kserve-controller] {"level":"error","ts":"2025-02-05T08:15:19Z","logger":"setup","msg":"unable to set up client config","error":"invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable","errorCauses":[{"error":"no configuration has been provided, try setting KUBERNETES_MASTER environment variable"}],"stacktrace":"main.main\n\t/root/parts/controller/build/cmd/manager/main.go:113\nruntime.main\n\t/snap/go/10807/src/runtime/proc.go:271"}
2025-02-05T08:15:23.436Z [kserve-controller] {"level":"info","ts":"2025-02-05T08:15:23Z","logger":"setup","msg":"Setting up client for manager"}
2025-02-05T08:15:23.436Z [kserve-controller] {"level":"error","ts":"2025-02-05T08:15:23Z","logger":"controller-runtime.client.config","msg":"unable to load in-cluster config","error":"unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined","stacktrace":"sigs.k8s.io/controller-runtime/pkg/client/config.loadConfig.func1\n\t/root/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.5/pkg/client/config/config.go:133\nsigs.k8s.io/controller-runtime/pkg/client/config.loadConfig\n\t/root/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.5/pkg/client/config/config.go:155\nsigs.k8s.io/controller-runtime/pkg/client/config.GetConfigWithContext\n\t/root/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.5/pkg/client/config/config.go:97\nsigs.k8s.io/controller-runtime/pkg/client/config.GetConfig\n\t/root/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.18.5/pkg/client/config/config.go:77\nmain.main\n\t/root/parts/controller/build/cmd/manager/main.go:111\nruntime.main\n\t/snap/go/10807/src/runtime/proc.go:271"}
2025-02-05T08:15:23.436Z [kserve-controller] {"level":"error","ts":"2025-02-05T08:15:23Z","logger":"setup","msg":"unable to set up client config","error":"invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable","errorCauses":[{"error":"no configuration has been provided, try setting KUBERNETES_MASTER environment variable"}],"stacktrace":"main.main\n\t/root/parts/controller/build/cmd/manager/main.go:113\nruntime.main\n\t/snap/go/10807/src/runtime/proc.go:271"}
````
