### PR TITLE
Update rock for sklearnserver

### DIFF
--- a/sklearnserver/dummy_pyproject.toml
+++ b/sklearnserver/dummy_pyproject.toml
@@ -5,7 +5,9 @@ description = ""
 authors = ["none"]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.12"
+# The Python version should match the range used in upstream:
+# https://github.com/kserve/kserve/blob/564cc2d760b7f47e883a4001876cd98815cfc07d/python/sklearnserver/pyproject.toml#L13
+python = ">=3.9,<3.13"
 kserve = { path = "../python/kserve", develop = false }
 sklearnserver = { path = "../python/sklearnserver", develop = false }
 

--- a/sklearnserver/rockcraft.yaml
+++ b/sklearnserver/rockcraft.yaml
@@ -1,4 +1,4 @@
-# Based on https://github.com/kserve/kserve/blob/v0.13.0/python/sklearn.Dockerfile
+# Based on https://github.com/kserve/kserve/blob/v0.14.1/python/sklearn.Dockerfile
 # 
 # See ../CONTRIBUTING.md for more details about the patterns used in this rock. 
 # This rock is implemented with some atypical patterns due to the native of the upstream
@@ -6,7 +6,7 @@
 name: sklearnserver
 summary: sklearn server for Kserve deployments
 description: "Kserve sklearn server"
-version: "0.13.0"
+version: "0.14.1"
 license: Apache-2.0
 base: ubuntu@22.04
 platforms:
@@ -33,12 +33,12 @@ parts:
     plugin: nil
     source: https://github.com/kserve/kserve.git
     source-subdir: python
-    source-tag: v0.13.0
+    source-tag: v0.14.1
     build-packages:
       - build-essential
       - libgomp1
     overlay-packages:
-    - python3.10  
+    - python3.11  
     # Including python3-pip here means pip also gets primed for the final rock
     - python3-pip
     override-build: |
@@ -46,7 +46,7 @@ parts:
       # the server in the final rock
       
       # Setup poetry
-      pip install poetry==1.7.1
+      pip install poetry==1.8.3
       poetry config virtualenvs.create false 
 
       # Install the kserve package, this specific server package, and their dependencies.
@@ -55,13 +55,13 @@ parts:
       (cd python_env_builddir && poetry install --no-interaction --no-root)
 
       # Promote the packages we've installed from the local env to the primed image
-      mkdir -p $CRAFT_PART_INSTALL/usr/local/lib/python3.10/dist-packages
-      cp -fr /usr/local/lib/python3.10/dist-packages/* $CRAFT_PART_INSTALL/usr/local/lib/python3.10/dist-packages/
+      mkdir -p $CRAFT_PART_INSTALL/usr/local/lib/python3.11/dist-packages
+      cp -fr /usr/local/lib/python3.11/dist-packages/* $CRAFT_PART_INSTALL/usr/local/lib/python3.11/dist-packages/
 
       # Ensure `python` is an executable command in our primed image by making
       # a symbolic link
       mkdir -p $CRAFT_PART_INSTALL/usr/bin/
-      ln -s /usr/bin/python3.10 $CRAFT_PART_INSTALL/usr/bin/python
+      ln -s /usr/bin/python3.11 $CRAFT_PART_INSTALL/usr/bin/python
 
   # Copy licenses
   third-party:
@@ -69,7 +69,7 @@ parts:
     after: [python]
     source: https://github.com/kserve/kserve.git
     source-subdir: python
-    source-tag: v0.13.0
+    source-tag: v0.14.1
     override-build: |
       cp -fr third_party/* ${CRAFT_PART_INSTALL}/third_party
 

--- a/sklearnserver/rockcraft.yaml
+++ b/sklearnserver/rockcraft.yaml
@@ -37,13 +37,15 @@ parts:
     build-packages:
       - build-essential
       - libgomp1
+      - python3.11
+      - python3.11-venv
+      - python3-venv
     overlay-packages:
-    - python3.11  
-    # Including python3-pip here means pip also gets primed for the final rock
-    - python3-pip
+      - python3.11
     override-build: |
-      # Populate the build system's python environment with all packages needed for 
-      # the server in the final rock
+      # Use Python 3.11
+      update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
+      update-alternatives --set python3 /usr/bin/python3.11
       
       # Setup poetry
       pip install poetry==1.8.3

--- a/sklearnserver/tests/test_rock.py
+++ b/sklearnserver/tests/test_rock.py
@@ -47,7 +47,7 @@ def test_rock(rock_test_env):
             "/bin/bash",
             LOCAL_ROCK_IMAGE,
             "-c",
-            "ls -la /usr/local/lib/python3.10/dist-packages/sklearnserver",
+            "ls -la /usr/local/lib/python3.11/dist-packages/sklearnserver",
         ],
         check=True,
     )
@@ -59,7 +59,7 @@ def test_rock(rock_test_env):
             "/bin/bash",
             LOCAL_ROCK_IMAGE,
             "-c",
-            "ls -la /usr/local/lib/python3.10/dist-packages/kserve",
+            "ls -la /usr/local/lib/python3.11/dist-packages/kserve",
         ],
         check=True,
     )

--- a/sklearnserver/tox.ini
+++ b/sklearnserver/tox.ini
@@ -24,7 +24,7 @@ commands =
 passenv = *
 allowlist_externals =
     bash
-    skopeo
+	rockcraft
     yq
 commands =
     # pack rock and export to docker
@@ -34,7 +34,7 @@ commands =
              ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
              DOCKER_IMAGE=$NAME:$VERSION && \
              echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
-             skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+             rockcraft.skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
 
 [testenv:sanity]
 passenv = *


### PR DESCRIPTION
This PR updates the `sklearnserver` rock to the version used by kserve `0.14.1`.

Expected output after you pack the rock with `tox -e pack` and run it:
```
docker run --entrypoint bash -it edb02ee75964
_daemon_@b658fcff84b6:/$ python --version
Python 3.11.0rc1
_daemon_@b658fcff84b6:/$ python -m sklearnserver
usage: __main__.py [-h] [--http_port HTTP_PORT] [--grpc_port GRPC_PORT] [--workers WORKERS] [--max_threads MAX_THREADS]
                   [--max_asyncio_workers MAX_ASYNCIO_WORKERS] [--enable_grpc ENABLE_GRPC] [--enable_docs_url ENABLE_DOCS_URL]
                   [--enable_latency_logging ENABLE_LATENCY_LOGGING] [--configure_logging CONFIGURE_LOGGING]
                   [--log_config_file LOG_CONFIG_FILE] [--access_log_format ACCESS_LOG_FORMAT] [--model_name MODEL_NAME]
                   [--predictor_host PREDICTOR_HOST] [--protocol {v1,v2,grpc-v2}] [--predictor_protocol {v1,v2,grpc-v2}]
                   [--predictor_use_ssl PREDICTOR_USE_SSL] [--predictor_request_timeout_seconds PREDICTOR_REQUEST_TIMEOUT_SECONDS]
                   [--grpc_max_send_message_length GRPC_MAX_SEND_MESSAGE_LENGTH]
                   [--grpc_max_receive_message_length GRPC_MAX_RECEIVE_MESSAGE_LENGTH] --model_dir MODEL_DIR
__main__.py: error: the following arguments are required: --model_dir
_daemon_@b658fcff84b6:/$
```