### PR TITLE
feat: update paddleserver for version 0.14.1

### DIFF
--- a/paddleserver/dummy_pyproject.toml
+++ b/paddleserver/dummy_pyproject.toml
@@ -5,8 +5,8 @@ description = ""
 authors = ["none"]
 
 [tool.poetry.dependencies]
-# This range should match that used upstream: https://github.com/kserve/kserve/blob/v0.11.2/python/paddleserver/pyproject.toml#L13
-python = ">=3.8,<3.11"
+# This range should match that used upstream: https://github.com/kserve/kserve/blob/v0.14.1/python/paddleserver/pyproject.toml#L13C1-L13C23
+python = ">=3.9,<3.13"
 kserve = { path = "../python/kserve", develop = false }
 paddleserver = { path = "../python/paddleserver", develop = false }
 

--- a/paddleserver/rockcraft.yaml
+++ b/paddleserver/rockcraft.yaml
@@ -39,7 +39,6 @@ parts:
     - python3.11-venv
     overlay-packages:
     - python3.11
-    - build-essential
     override-build: |
       # Ensure Python 3.11 is the default version
       update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1

--- a/paddleserver/rockcraft.yaml
+++ b/paddleserver/rockcraft.yaml
@@ -1,4 +1,4 @@
-# Based on https://github.com/kserve/kserve/blob/v0.13.0/python/paddle.Dockerfile
+# Based on https://github.com/kserve/kserve/blob/v0.14.1/python/paddle.Dockerfile
 # 
 # See ../CONTRIBUTING.md for more details about the patterns used in this rock. 
 # This rock is implemented with some atypical patterns due to the native of the upstream
@@ -6,7 +6,7 @@
 name: paddleserver
 summary: Paddle server for Kserve deployments
 description: "Kserve Paddle server"
-version: "0.13.0"
+version: "0.14.1"
 license: Apache-2.0
 base: ubuntu@22.04
 platforms:
@@ -33,22 +33,20 @@ parts:
     plugin: nil
     source: https://github.com/kserve/kserve.git
     source-subdir: python
-    source-tag: v0.13.0
+    source-tag: v0.14.1
     build-packages:
-      - build-essential
-      - libgomp1
-    stage-packages:
-      - libgomp1
+    - python3.11
+    - python3.11-venv
     overlay-packages:
-    - python3.10  
-    # Including python3-pip here means pip also gets primed for the final rock
-    - python3-pip
+    - python3.11
+    - build-essential
     override-build: |
-      # Populate the build system's python environment with all packages needed for 
-      # the server in the final rock
-      
+      # Ensure Python 3.11 is the default version
+      update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
+      update-alternatives --set python3 /usr/bin/python3.11
+
       # Setup poetry
-      pip install poetry==1.7.1
+      python3 -m pip install --upgrade pip setuptools poetry==1.8.3
       poetry config virtualenvs.create false 
 
       # Install the kserve package, this specific server package, and their dependencies.
@@ -57,13 +55,12 @@ parts:
       (cd python_env_builddir && poetry install --no-interaction --no-root)
 
       # Promote the packages we've installed from the local env to the primed image
-      mkdir -p $CRAFT_PART_INSTALL/usr/local/lib/python3.10/dist-packages
-      cp -fr /usr/local/lib/python3.10/dist-packages/* $CRAFT_PART_INSTALL/usr/local/lib/python3.10/dist-packages/
+      mkdir -p $CRAFT_PART_INSTALL/usr/local/lib/python3.11/dist-packages
+      cp -fr /usr/local/lib/python3.11/dist-packages/* $CRAFT_PART_INSTALL/usr/local/lib/python3.11/dist-packages/
 
-      # Ensure `python` is an executable command in our primed image by making
-      # a symbolic link
+      # Ensure `python` is an executable command in our primed image
       mkdir -p $CRAFT_PART_INSTALL/usr/bin/
-      ln -s /usr/bin/python3.10 $CRAFT_PART_INSTALL/usr/bin/python
+      ln -s /usr/bin/python3.11 $CRAFT_PART_INSTALL/usr/bin/python
 
   # Copy licenses
   third-party:
@@ -71,7 +68,6 @@ parts:
     after: [python]
     source: https://github.com/kserve/kserve.git
     source-subdir: python
-    source-tag: v0.13.0
+    source-tag: v0.14.1
     override-build: |
       cp -fr third_party/* ${CRAFT_PART_INSTALL}/third_party
-

--- a/paddleserver/tests/test_rock.py
+++ b/paddleserver/tests/test_rock.py
@@ -47,7 +47,7 @@ def test_rock(rock_test_env):
             "/bin/bash",
             LOCAL_ROCK_IMAGE,
             "-c",
-            "ls -la /usr/local/lib/python3.10/dist-packages/paddleserver",
+            "ls -la /usr/local/lib/python3.11/dist-packages/paddleserver",
         ],
         check=True,
     )
@@ -59,7 +59,7 @@ def test_rock(rock_test_env):
             "/bin/bash",
             LOCAL_ROCK_IMAGE,
             "-c",
-            "ls -la /usr/local/lib/python3.10/dist-packages/kserve",
+            "ls -la /usr/local/lib/python3.11/dist-packages/kserve",
         ],
         check=True,
     )

--- a/paddleserver/tox.ini
+++ b/paddleserver/tox.ini
@@ -24,7 +24,7 @@ commands =
 passenv = *
 allowlist_externals =
     bash
-    skopeo
+	rockcraft
     yq
 commands =
     # pack rock and export to docker
@@ -34,7 +34,7 @@ commands =
              ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
              DOCKER_IMAGE=$NAME:$VERSION && \
              echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
-             skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+             rockcraft.skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
 
 [testenv:sanity]
 passenv = *


### PR DESCRIPTION
Closes: https://warthogs.atlassian.net/browse/KF-6818

Changes:
- python bump to 3.11 
- I had to use build packages in combination with overlay packages as the default python for 22.04 is 3.10 and it just keeps overriding the build python to 3.10.

Test
```
rockcraft clean && rockcraft pack --verbosity=trace --debug
sudo rockcraft.skopeo --insecure-policy copy oci-archive:paddleserver_0.14.1_amd64.rock docker-daemon:misohu/paddleserver:0.14.1
docker run misohu/paddleserver:0.14.1
docker exec -ti <container> bash

# Expected output
_daemon_@ae1df4026bf8:/$ python --version
Python 3.11.0rc1
_daemon_@ae1df4026bf8:/$ python -m pmmlserver
usage: __main__.py [-h] [--http_port HTTP_PORT] [--grpc_port GRPC_PORT] [--workers WORKERS] [--max_threads MAX_THREADS] [--max_asyncio_workers MAX_ASYNCIO_WORKERS] [--enable_grpc ENABLE_GRPC]
                   [--enable_docs_url ENABLE_DOCS_URL] [--enable_latency_logging ENABLE_LATENCY_LOGGING] [--configure_logging CONFIGURE_LOGGING] [--log_config_file LOG_CONFIG_FILE]
                   [--access_log_format ACCESS_LOG_FORMAT] [--model_name MODEL_NAME] [--predictor_host PREDICTOR_HOST] [--protocol {v1,v2,grpc-v2}] [--predictor_protocol {v1,v2,grpc-v2}]
                   [--predictor_use_ssl PREDICTOR_USE_SSL] [--predictor_request_timeout_seconds PREDICTOR_REQUEST_TIMEOUT_SECONDS] [--grpc_max_send_message_length GRPC_MAX_SEND_MESSAGE_LENGTH]
                   [--grpc_max_receive_message_length GRPC_MAX_RECEIVE_MESSAGE_LENGTH] --model_dir MODEL_DIR
__main__.py: error: the following arguments are required: --model_dir
```




