### PR TITLE
chore: update lgbserver rock to 0.14.1

### DIFF
--- a/lgbserver/dummy_pyproject.toml
+++ b/lgbserver/dummy_pyproject.toml
@@ -5,8 +5,9 @@ description = ""
 authors = ["none"]
 
 [tool.poetry.dependencies]
-# This range should match that used in upstream's server pyproject.toml
-python = ">=3.8,<3.12"
+# This range should match that used in upstream's server pyproject.toml:
+# https://github.com/kserve/kserve/blob/v0.14.1/python/lgbserver/pyproject.toml#L13
+python = ">=3.9,<3.13"
 kserve = { path = "../python/kserve", develop = false }
 lgbserver = { path = "../python/lgbserver", develop = false }
 

--- a/lgbserver/rockcraft.yaml
+++ b/lgbserver/rockcraft.yaml
@@ -39,8 +39,6 @@ parts:
     - python3.11-venv
     overlay-packages:
     - python3.11
-    - gcc
-    - build-essential
     override-build: |
       # Ensure Python 3.11 is the default version
       update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1

--- a/lgbserver/rockcraft.yaml
+++ b/lgbserver/rockcraft.yaml
@@ -1,4 +1,4 @@
-# Based on https://github.com/kserve/kserve/blob/v0.13.0/python/lgb.Dockerfile
+# Based on https://github.com/kserve/kserve/blob/v0.14.1/python/lgb.Dockerfile
 # 
 # See ../CONTRIBUTING.md for more details about the patterns used in this rock. 
 # This rock is implemented with some atypical patterns due to the native of the upstream
@@ -6,7 +6,7 @@
 name: lgbserver
 summary: LightGBM server for Kserve deployments
 description: "Kserve LightGBM server"
-version: "0.13.0"
+version: "0.14.1"
 license: Apache-2.0
 base: ubuntu@22.04
 platforms:
@@ -33,22 +33,21 @@ parts:
     plugin: nil
     source: https://github.com/kserve/kserve.git
     source-subdir: python
-    source-tag: v0.13.0
+    source-tag: v0.14.1
     build-packages:
-      - build-essential
-      - libgomp1
-    stage-packages:
-      - libgomp1
+    - python3.11
+    - python3.11-venv
     overlay-packages:
-    - python3.10  
-    # Including python3-pip here means pip also gets primed for the final rock
-    - python3-pip
+    - python3.11
+    - gcc
+    - build-essential
     override-build: |
-      # Populate the build system's python environment with all packages needed for 
-      # the server in the final rock
+      # Ensure Python 3.11 is the default version
+      update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
+      update-alternatives --set python3 /usr/bin/python3.11
       
       # Setup poetry
-      pip install poetry==1.7.1
+      python3 -m pip install --upgrade pip setuptools poetry==1.8.3
       poetry config virtualenvs.create false 
 
       # Install the kserve package, this specific server package, and their dependencies.
@@ -57,13 +56,13 @@ parts:
       (cd python_env_builddir && poetry install --no-interaction --no-root)
 
       # Promote the packages we've installed from the local env to the primed image
-      mkdir -p $CRAFT_PART_INSTALL/usr/local/lib/python3.10/dist-packages
-      cp -fr /usr/local/lib/python3.10/dist-packages/* $CRAFT_PART_INSTALL/usr/local/lib/python3.10/dist-packages/
+      mkdir -p $CRAFT_PART_INSTALL/usr/local/lib/python3.11/dist-packages
+      cp -fr /usr/local/lib/python3.11/dist-packages/* $CRAFT_PART_INSTALL/usr/local/lib/python3.11/dist-packages/
 
       # Ensure `python` is an executable command in our primed image by making
       # a symbolic link
       mkdir -p $CRAFT_PART_INSTALL/usr/bin/
-      ln -s /usr/bin/python3.10 $CRAFT_PART_INSTALL/usr/bin/python
+      ln -s /usr/bin/python3.11 $CRAFT_PART_INSTALL/usr/bin/python
 
   # Copy licenses
   third-party:
@@ -71,7 +70,7 @@ parts:
     after: [python]
     source: https://github.com/kserve/kserve.git
     source-subdir: python
-    source-tag: v0.13.0
+    source-tag: v0.14.1
     override-build: |
       cp -fr third_party/* ${CRAFT_PART_INSTALL}/third_party
 

--- a/lgbserver/tests/test_rock.py
+++ b/lgbserver/tests/test_rock.py
@@ -42,7 +42,7 @@ def test_rock(rock_test_env):
             "/bin/bash",
             LOCAL_ROCK_IMAGE,
             "-c",
-            "ls -la /usr/local/lib/python3.10/dist-packages/lgbserver",
+            "ls -la /usr/local/lib/python3.11/dist-packages/lgbserver",
         ],
         check=True,
     )
@@ -54,7 +54,7 @@ def test_rock(rock_test_env):
             "/bin/bash",
             LOCAL_ROCK_IMAGE,
             "-c",
-            "ls -la /usr/local/lib/python3.10/dist-packages/kserve",
+            "ls -la /usr/local/lib/python3.11/dist-packages/kserve",
         ],
         check=True,
     )

--- a/lgbserver/tox.ini
+++ b/lgbserver/tox.ini
@@ -24,7 +24,7 @@ commands =
 passenv = *
 allowlist_externals =
     bash
-    skopeo
+    rockcraft
     yq
 commands =
     # pack rock and export to docker
@@ -34,7 +34,7 @@ commands =
              ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
              DOCKER_IMAGE=$NAME:$VERSION && \
              echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
-             skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+             rockcraft.skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
 
 [testenv:sanity]
 passenv = *


### PR DESCRIPTION
Closes https://warthogs.atlassian.net/browse/KF-6812

## Testing
Tested by following the instructions in https://github.com/canonical/kserve-rocks/tree/main/lgbserver#testing
Output of inference request:
```
curl -v \
  -H "Content-Type: application/json" \
  -d @./iris-input-v2.json \
  localhost:8080/v2/models/test_model/infer
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> POST /v2/models/test_model/infer HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/8.1.2
> Accept: */*
> Content-Type: application/json
> Content-Length: 178
> 
< HTTP/1.1 200 OK
< date: Mon, 10 Feb 2025 09:54:03 GMT
< server: uvicorn
< content-length: 327
< content-type: application/json
< 
* Connection #0 to host localhost left intact
{"model_name":"test_model","model_version":null,"id":"063a1abb-98d1-4b1b-be4b-ec5a9aa4e72e","parameters":null,"outputs":[{"name":"output-0","shape":[2,3],"datatype":"FP64","parameters":null,"data":[0.00028762259763255566,0.9763481320224064,0.023364245379961103,0.0005625431624697456,0.9988642605470336,0.0005731962904966214]}]}
```