### PR TITLE
Add libgomp1 package in stage packages of {lgbserver, paddleserver}

### DIFF
--- a/lgbserver/rockcraft.yaml
+++ b/lgbserver/rockcraft.yaml
@@ -39,6 +39,10 @@ parts:
     - python3.11-venv
     overlay-packages:
     - python3.11
+    stage-packages:
+    # Packages required for the rock to work
+    # https://github.com/kserve/kserve/blob/v0.14.1/python/lgb.Dockerfile#L39
+    - libgomp1
     override-build: |
       # Ensure Python 3.11 is the default version
       update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1

--- a/paddleserver/rockcraft.yaml
+++ b/paddleserver/rockcraft.yaml
@@ -37,6 +37,10 @@ parts:
     build-packages:
     - python3.11
     - python3.11-venv
+    stage-packages:
+    # Packages required for the rock to work
+    # https://github.com/kserve/kserve/blob/v0.14.1/python/paddle.Dockerfile#L39
+    - libgomp1
     overlay-packages:
     - python3.11
     override-build: |


### PR DESCRIPTION
Closes https://github.com/canonical/kserve-operators/issues/316

This PR adds as `stage-packages` in `lgbserver` and `paddleserver` the `libgomp1` package, which is needed for actually running the executables

## To test that it is working
- First, clone, this repository, checkout to this branch, and build the 2 images with `rockcraft pack`
- Push them to a Docker registry that is reachable with `docker tag`, `docker push` (I am using my own account for this)
- `git clone https://github.com/canonical/kserve-operators`
- Edit the file in `charms/kserve-controller/src/default-custom-images.json`, and put the image location that you pushed earlier
- Run the integration tests with `tox -e integration`, and they should pass :)