### PR TITLE
Add `Kserve Router` rock and tests

### DIFF
--- a/router/rockcraft.yaml
+++ b/router/rockcraft.yaml
@@ -1,0 +1,58 @@
+# Based on https://github.com/kserve/kserve/blob/v0.14.1/router.Dockerfile
+name: kserve-router
+summary: KServe Router
+description: "KServe Router"
+version: "0.14.1"
+license: Apache-2.0
+base: ubuntu@22.04
+platforms:
+    amd64:
+run-user: _daemon_
+
+services:
+  kserve-router:
+    override: replace
+    summary: "KServe router service"
+    startup: enabled
+    command: "/ko-app/router"
+
+parts:
+  security-team-requirement:
+    plugin: nil
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+      dpkg-query --root=${CRAFT_PROJECT_DIR}/../bundles/ubuntu-22.04/rootfs/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
+      > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
+
+  router:
+    plugin: go
+    source: https://github.com/kserve/kserve
+    source-type: git
+    source-tag: v0.14.1
+    build-snaps:
+      - go/1.22/stable
+    build-environment:
+      - CGO_ENABLED: 0
+      - GOOS: linux
+    override-build: |
+
+      # Empty the build directory and copy the build files that are
+      # specified in the upstream Dockerfile.
+      rm -rf ./*
+
+      # Copy in the go src
+      cp $CRAFT_PART_SRC/go.mod $CRAFT_PART_SRC/go.sum ./
+
+      go mod download
+
+      cp -r $CRAFT_PART_SRC/cmd ./cmd
+      cp -r $CRAFT_PART_SRC/pkg ./pkg
+
+      # Build
+      go build -a -o router ./cmd/router
+
+      # Copy the files to the install directory
+      cp -r $CRAFT_PART_SRC/third_party/ $CRAFT_PART_INSTALL/third_party/
+      mkdir $CRAFT_PART_INSTALL/ko-app
+      cp -r router $CRAFT_PART_INSTALL/ko-app/router

--- a/router/tests/test_rock.py
+++ b/router/tests/test_rock.py
@@ -1,0 +1,36 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import pytest
+import subprocess
+
+from charmed_kubeflow_chisme.rock import CheckRock
+
+
+@pytest.mark.abort_on_fail
+def test_rock():
+    """Test rock."""
+    check_rock = CheckRock("rockcraft.yaml")
+    rock_image = check_rock.get_name()
+    rock_version = check_rock.get_version()
+    LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
+
+    # assert the rock contains the expected files
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            LOCAL_ROCK_IMAGE,
+            "exec",
+            "ls",
+            "-la",
+            "/third_party",
+        ],
+        check=True,
+    )
+
+    subprocess.run(
+        ["docker", "run", "--rm", LOCAL_ROCK_IMAGE, "exec", "ls", "-la", "/ko-app/router"],
+        check=True,
+    )

--- a/router/tox.ini
+++ b/router/tox.ini
@@ -1,0 +1,54 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+[tox]
+skipsdist = True
+skip_missing_interpreters = True
+envlist = pack, export-to-docker, sanity, integration
+
+[testenv]
+setenv =
+    PYTHONPATH={toxinidir}
+    PYTHONBREAKPOINT=ipdb.set_trace
+    CHARM_REPO=https://github.com/canonical/kserve-operators.git
+    CHARM_BRANCH=main
+    LOCAL_CHARM_DIR=charm_repo
+
+[testenv:pack]
+passenv = *
+allowlist_externals =
+    rockcraft
+commands =
+    rockcraft pack
+
+[testenv:export-to-docker]
+passenv = *
+allowlist_externals =
+    bash
+    skopeo
+    yq
+commands =
+    # export rock to docker
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval ".platforms | keys | .[0]" rockcraft.yaml) && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
+             DOCKER_IMAGE=$NAME:$VERSION && \
+             echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
+             skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+
+[testenv:sanity]
+passenv = *
+deps =
+    pytest
+    charmed-kubeflow-chisme
+commands =
+    # run rock tests
+    pytest -s -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
+
+[testenv:integration]
+passenv = *
+allowlist_externals =
+    echo
+commands =
+    # TODO: Implement integration tests here
+    echo "WARNING: This is a placeholder test - no test is implemented here."


### PR DESCRIPTION
# Changes
Added rock for Kserve Router. See [source](https://github.com/kserve/kserve/tree/v0.14.1/cmd/router)
# Files
- Add rockcraft.yaml
- Add tests
- Add tox.ini
# Testing

I uploaded rock to local microk8s. Then I activated it through `config.yaml`, `config-map-data.yaml`, `config-map-data-changed.yaml`,`default-custom-images.json`, in kserve-controller charm from [here](https://github.com/canonical/kserve-operators) and then run  integration tests. 

Status of `juju status --relations` after testing

```
Model     Controller                Cloud/Region        Version  SLA          Timestamp
kubeflow  github-pr-a184f-microk8s  microk8s/localhost  3.6.3    unsupported  12:34:11+02:00

App                      Version                Status   Scale  Charm                    Channel          Rev  Address         Exposed  Message
grafana-agent-k8s        0.40.4                 blocked      1  grafana-agent-k8s        latest/stable    105  10.152.183.66   no       Missing ['grafana-cloud-config']|['logging-consumer'] for logging-provider; ['grafana-cloud-config']|['send-remote-wr...
istio-ingressgateway                            active       1  istio-gateway            1.16/stable     1005  10.152.183.165  no       
istio-pilot                                     active       1  istio-pilot              1.16/stable      662  10.152.183.143  no       
knative-operator                                active       1  knative-operator         latest/edge      711  10.152.183.36   no       
knative-serving                                 active       1  knative-serving          latest/edge      749  10.152.183.191  no       
kserve-controller                               blocked      1  kserve-controller                           0  10.152.183.29   no       Cannot parse a config-defined images list from config '{' - thisconfig input will be ignored.
metacontroller-operator                         active       1  metacontroller-operator  latest/edge      446  10.152.183.243  no       
minio                    res:oci-image@1755999  active       1  minio                    ckf-1.7/stable   214  10.152.183.247  no       
resource-dispatcher                             active       1  resource-dispatcher      latest/edge      280  10.152.183.162  no       

Unit                        Workload  Agent  Address       Ports          Message
grafana-agent-k8s/0*        blocked   idle   10.1.224.70                  Missing ['grafana-cloud-config']|['logging-consumer'] for logging-provider; ['grafana-cloud-config']|['send-remote-wr...
istio-ingressgateway/0*     active    idle   10.1.224.65                  
istio-pilot/0*              active    idle   10.1.224.76                  
knative-operator/0*         active    idle   10.1.224.82                  
knative-serving/0*          active    idle   10.1.224.85                  
kserve-controller/0*        blocked   idle   10.1.224.126                 Cannot parse a config-defined images list from config '{' - thisconfig input will be ignored.
metacontroller-operator/0*  active    idle   10.1.224.110                 
minio/0*                    active    idle   10.1.224.109  9000-9001/TCP  
resource-dispatcher/0*      active    idle   10.1.224.94                  

Integration provider                  Requirer                            Interface              Type     Message
grafana-agent-k8s:logging-provider    kserve-controller:logging           loki_push_api          regular  
grafana-agent-k8s:peers               grafana-agent-k8s:peers             grafana_agent_replica  peer     
istio-pilot:gateway-info              kserve-controller:ingress-gateway   istio-gateway-info     regular  
istio-pilot:istio-pilot               istio-ingressgateway:istio-pilot    k8s-service            regular  
knative-serving:local-gateway         kserve-controller:local-gateway     serving-local-gateway  regular  
kserve-controller:metrics-endpoint    grafana-agent-k8s:metrics-endpoint  prometheus_scrape      regular  
minio:object-storage                  kserve-controller:object-storage    object-storage         regular  
resource-dispatcher:secrets           kserve-controller:secrets           kubernetes_manifest    regular  
resource-dispatcher:service-accounts  kserve-controller:service-accounts  kubernetes_manifest    regular  
```

Logs of passed integration tests `tox -e controller-integration -- --model kubeflow -vv -s`

```
============================================================================================= 19 passed in 1755.32s (0:29:15) =============================================================================================
  integration: OK (1757.48=setup[0.10]+cmd[1757.38] seconds)
  congratulations :) (1757.61 seconds)
  controller-integration: OK (1757.98=setup[0.08]+cmd[1757.90] seconds)
  congratulations :) (1758.18 seconds)

```