### PR TITLE
controller: Override the readOnlyRootFilesystem for router

### DIFF
--- a/controller/rockcraft.yaml
+++ b/controller/rockcraft.yaml
@@ -33,21 +33,20 @@ parts:
     build-snaps:
       - go/1.22/stable
     build-environment:
-      - CGO_ENABLED: 0
+      - CGO_ENABLED: "0"
       - GOOS: linux
     override-build: |
-
-      # Empty the build directory and copy the build files that are
-      # specified in the upstream Dockerfile.
-      rm -rf ./*
-
-      # Copy in the go src
-      cp $CRAFT_PART_SRC/go.mod $CRAFT_PART_SRC/go.sum ./
+      # Patch ReadOnlyRootFilesystem when creating the router Deployment, so that
+      # the container will have a writable file system.
+      # More details in https://github.com/canonical/kserve-operators/issues/328.
+      # Remove once pebble won't need to always write some state to disk
+      # https://github.com/canonical/pebble/issues/462.
+      sed -i \
+          's#ReadOnlyRootFilesystem:   proto.Bool(true)#ReadOnlyRootFilesystem:   proto.Bool(false)#' \
+          pkg/controller/v1alpha1/inferencegraph/knative_reconciler.go \
+          pkg/controller/v1alpha1/inferencegraph/raw_ig.go
 
       go mod download
-
-      cp -r $CRAFT_PART_SRC/cmd ./cmd
-      cp -r $CRAFT_PART_SRC/pkg ./pkg
 
       # Build
       go build -a -o manager ./cmd/manager


### PR DESCRIPTION
Closes https://github.com/canonical/kserve-operators/issues/328

Updates the KServe Controller to not set `readOnlyRootFilesystem` to `True` when creating the Router Knative Service, for an `InferenceGraph`.
## Testing
1. Deploy CKF 1.10
2. Follow the instructions [here](https://kserve.github.io/website/master/modelserving/inference_graph/image_pipeline/#deploy-inferencegraph) to create an `InferenceGraph`  
    * The notebook doesn't have permissions https://github.com/canonical/kserve-operators/issues/327. You'll need to edit the `kubeflow-kserve-edit` ClusterRole to give permissions for `inferencegraphs`
3. Confirm that the Router deployment in the user namespace has `readOnlyRootFilesystem` for the Router container
    * The Router Knative Service gets created after the other InferenceServices are ready
    * The Knative Service has also a `queue` sidecar container with `readOnlyRootFilesystem` but this is handled by https://github.com/canonical/knative-rocks/issues/44