### PR TITLE
feat(agent): Add rock-ci-metadata.yaml

### DIFF
--- a/agent/rock-ci-metadata.yaml
+++ b/agent/rock-ci-metadata.yaml
@@ -1,0 +1,10 @@
+integrations:
+  - consumer-repository: https://github.com/canonical/kserve-operators.git
+
+    replace-image:
+      - file: charms/kserve-controller/src/default-custom-images.json
+        path: configmap__agent
+      - file: charms/kserve-controller/src/default-custom-images.json
+        path: configmap__batcher
+      - file: charms/kserve-controller/src/default-custom-images.json
+        path: configmap__logger


### PR DESCRIPTION
Introduce a `rock-ci-metadata.yaml` for rock integration. For full file creation steps, refer to
https://github.com/canonical/pipelines-rocks/issues/200#issuecomment-3112245114.

Closes #127