### PR TITLE
feat(paddleserver): Add rock-ci-metadata.yaml

### DIFF
--- a/paddleserver/rock-ci-metadata.yaml
+++ b/paddleserver/rock-ci-metadata.yaml
@@ -1,0 +1,6 @@
+integrations:
+  - consumer-repository: https://github.com/canonical/kserve-operators.git
+
+    replace-image:
+      - file: charms/kserve-controller/src/default-custom-images.json
+        path: serving_runtimes__paddleserver


### PR DESCRIPTION
Introduce a `rock-ci-metadata.yaml` for rock integration. For full file creation steps, refer to
https://github.com/canonical/pipelines-rocks/issues/200#issuecomment-3112245114.

Closes #132