### PR TITLE
chore: Update `router` rock to `v0.15.2`

### DIFF
--- a/router/rockcraft.yaml
+++ b/router/rockcraft.yaml
@@ -1,8 +1,8 @@
-# Based on https://github.com/kserve/kserve/blob/v0.14.1/router.Dockerfile
+# Based on https://github.com/kserve/kserve/blob/v0.15.2/router.Dockerfile
 name: kserve-router
 summary: KServe Router
 description: "KServe Router"
-version: "0.14.1"
+version: "0.15.2"
 license: Apache-2.0
 base: ubuntu@22.04
 run-user: _daemon_
@@ -16,7 +16,7 @@ services:
     override: replace
     summary: "KServe router service"
     startup: enabled
-    command: "/ko-app/router [ ]"
+    command: "/ko-app/router [ dummy-arguments ]"
 
 
 parts:
@@ -32,9 +32,9 @@ parts:
     plugin: go
     source: https://github.com/kserve/kserve
     source-type: git
-    source-tag: v0.14.1
+    source-tag: v0.15.2
     build-snaps:
-      - go/1.22/stable
+      - go/1.24/stable
     build-environment:
       - CGO_ENABLED: 0
       - GOOS: linux
@@ -54,7 +54,14 @@ parts:
       # Build
       go build -a -o router ./cmd/router
 
+      # Generate third-party licenses
+      cp -r $CRAFT_PART_SRC/LICENSE ./LICENSE
+      go install github.com/google/go-licenses@latest
+      $GOBIN/go-licenses check ./cmd/... ./pkg/... --disallowed_types="forbidden,unknown"
+      $GOBIN/go-licenses save --save_path third_party/library ./cmd/agent
+      
       # Copy the files to the install directory
-      cp -r $CRAFT_PART_SRC/third_party/ $CRAFT_PART_INSTALL/third_party/
+      mkdir $CRAFT_PART_INSTALL/third_party
+      cp -r third_party $CRAFT_PART_INSTALL/third_party/
       mkdir $CRAFT_PART_INSTALL/ko-app
       cp -r router $CRAFT_PART_INSTALL/ko-app/router

--- a/router/rockcraft.yaml
+++ b/router/rockcraft.yaml
@@ -58,7 +58,7 @@ parts:
       cp -r $CRAFT_PART_SRC/LICENSE ./LICENSE
       go install github.com/google/go-licenses@latest
       $GOBIN/go-licenses check ./cmd/... ./pkg/... --disallowed_types="forbidden,unknown"
-      $GOBIN/go-licenses save --save_path third_party/library ./cmd/agent
+      $GOBIN/go-licenses save --save_path third_party/library ./cmd/router
       
       # Copy the files to the install directory
       mkdir $CRAFT_PART_INSTALL/third_party

--- a/router/tox.ini
+++ b/router/tox.ini
@@ -24,7 +24,7 @@ commands =
 passenv = *
 allowlist_externals =
     bash
-    skopeo
+	rockcraft
     yq
 commands =
     # export rock to docker
@@ -34,7 +34,7 @@ commands =
              ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
              DOCKER_IMAGE=$NAME:$VERSION && \
              echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
-             skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+             rockcraft.skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
 
 [testenv:sanity]
 passenv = *


### PR DESCRIPTION
Closes #183 

To ensure that the licenses are correctly places in the final OCI image, I packed the rock and used `dive` to inspect the image structure.