### PR TITLE
feat: add `huggingface-cpu` server

### DIFF
--- a/huggingfaceserver-cpu/dummy_pyproject.toml
+++ b/huggingfaceserver-cpu/dummy_pyproject.toml
@@ -1,0 +1,12 @@
+[tool.poetry]
+name = "workaround-for-editable-install"
+version = "0.0.1"
+description = ""
+authors = ["none"]
+
+[tool.poetry.dependencies]
+# This range should match that used upstream: https://github.com/kserve/kserve/blob/v0.15.2/python/pmmlserver/pyproject.toml#L13
+python = ">=3.9,<3.13"
+kserve = { path = "../python/kserve", develop = false }
+huggingfaceserver = { path = "../python/huggingfaceserver", develop = false }
+

--- a/huggingfaceserver-cpu/dummy_pyproject.toml
+++ b/huggingfaceserver-cpu/dummy_pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 authors = ["none"]
 
 [tool.poetry.dependencies]
-# This range should match that used upstream: https://github.com/kserve/kserve/blob/v0.15.2/python/pmmlserver/pyproject.toml#L13
+# This range should match that used upstream: https://github.com/kserve/kserve/blob/v0.15.2/python/huggingfaceserver/pyproject.toml#L11
 python = ">=3.9,<3.13"
 kserve = { path = "../python/kserve", develop = false }
 huggingfaceserver = { path = "../python/huggingfaceserver", develop = false }

--- a/huggingfaceserver-cpu/rock-ci-metadata.yaml
+++ b/huggingfaceserver-cpu/rock-ci-metadata.yaml
@@ -1,0 +1,1 @@
+integrations: []

--- a/huggingfaceserver-cpu/rockcraft.yaml
+++ b/huggingfaceserver-cpu/rockcraft.yaml
@@ -1,0 +1,129 @@
+# Based on https://github.com/kserve/kserve/blob/v0.15.2/python/huggingface_server_cpu.Dockerfile
+# See ../CONTRIBUTING.md for more details about the patterns used in this rock.
+
+name: huggingfaceserver-cpu
+summary: HuggingFace server for KServe deployments (CPU-only)
+description: "KServe HuggingFace server with PyTorch CPU + IPEX + vLLM (CPU)."
+version: "0.15.2"
+license: Apache-2.0
+base: ubuntu@22.04
+platforms:
+  amd64:
+
+run-user: _daemon_
+
+services:
+  huggingfaceserver:
+    override: replace
+    summary: "HuggingFace server (CPU)"
+    startup: enabled
+    command: "python -m huggingfaceserver [ dummy-arguments ]"
+    environment:
+      HF_HOME: "/tmp/huggingface"
+      HF_HUB_DISABLE_TELEMETRY: "1"
+      LD_PRELOAD: "/usr/lib/x86_64-linux-gnu/libtcmalloc.so.4:/usr/lib/x86_64-linux-gnu/libjemalloc.so.2"
+
+entrypoint-service: huggingfaceserver
+
+parts:
+  security-team-requirement:
+    plugin: nil
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+      dpkg-query --root=${CRAFT_PROJECT_DIR}/../bundles/ubuntu-22.04/rootfs/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
+      > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
+
+  python:
+    plugin: nil
+    source: https://github.com/kserve/kserve.git
+    source-subdir: python
+    source-tag: v0.15.2
+    build-packages:
+      - python3.10
+      - python3.10-venv
+      - python3.10-dev
+      - build-essential
+      - gcc-12
+      - g++-12
+      - git
+      - libnuma-dev
+      - pkg-config
+
+    overlay-packages:
+      - python3.10
+      - google-perftools
+      - libjemalloc2
+      - libnuma1
+      - numactl
+      - libgl1
+      - libglib2.0-0
+
+    override-build: |
+      # Match upstream: prefer GCC/G++ 12
+      update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 10 --slave /usr/bin/g++ g++ /usr/bin/g++-12
+
+      python3 -m pip install --upgrade pip setuptools poetry==1.8.3
+      poetry config virtualenvs.create false
+
+      mkdir -p ./python_env_builddir
+      cp -rf "$CRAFT_PROJECT_DIR/dummy_pyproject.toml" ./python_env_builddir/pyproject.toml
+
+      TORCH_VERSION="2.6.0"
+      TORCHVISION_VERSION="0.21.0"
+      TORCH_EXTRA_INDEX_URL="https://download.pytorch.org/whl/cpu"
+      IPEX_EXTRA_INDEX_URL="https://pytorch-extension.intel.com/release-whl/stable/cpu/us/"
+
+      pushd python_env_builddir
+        # Ensure path deps resolve to the checked-out repo paths
+        # dummy pyproject uses: ../python/kserve and ../python/huggingfaceserver
+        # Add PyTorch CPU index and pin torch family
+        poetry source add --priority=supplemental pytorch-cpu "${TORCH_EXTRA_INDEX_URL}"
+        poetry add --source pytorch-cpu \
+          "torch~=${TORCH_VERSION}" \
+          "torchaudio~=${TORCH_VERSION}" \
+          "torchvision~=${TORCHVISION_VERSION}"
+
+        poetry lock
+        poetry install --no-interaction --no-root
+      popd
+
+      # Intel Extension for PyTorch + OpenMP from extra indexes
+      python3 -m pip install --no-cache-dir \
+        --extra-index-url "${TORCH_EXTRA_INDEX_URL}" \
+        --extra-index-url "${IPEX_EXTRA_INDEX_URL}" \
+        "intel_extension_for_pytorch~=${TORCH_VERSION}" \
+        intel-openmp
+
+      # vLLM (CPU) build
+      VLLM_VERSION="0.8.5"
+      export VLLM_CPU_DISABLE_AVX512="true"
+      export VLLM_CPU_AVX512BF16="1"
+      export VLLM_TARGET_DEVICE="cpu"
+
+      git clone --single-branch --branch "v${VLLM_VERSION}" https://github.com/vllm-project/vllm.git
+      pushd vllm
+        python3 -m pip install --no-cache-dir -r requirements/build.txt
+        python3 -m pip install --no-cache-dir -r requirements/cpu.txt
+        python3 setup.py bdist_wheel
+        python3 -m pip install --no-cache-dir dist/vllm-${VLLM_VERSION}*.whl
+      popd
+
+      # Third-party licenses (mirror upstream)
+      cd python
+      cp -f third_party/pip-licenses.py ./pip-licenses.py
+      python3 -m pip install --no-cache-dir tomli
+      mkdir -p third_party/library
+      python3 pip-licenses.py
+
+      # Promote installed packages into the primed image
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/local/lib/python3.10/dist-packages
+      cp -fr /usr/local/lib/python3.10/dist-packages/* ${CRAFT_PART_INSTALL}/usr/local/lib/python3.10/dist-packages/ || true
+
+      # Ensure `python` exists in the primed image
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/bin
+      ln -sf /usr/bin/python3.10 ${CRAFT_PART_INSTALL}/usr/bin/python
+
+      # Third-party licenses payload
+      mkdir -p ${CRAFT_PART_INSTALL}/third_party
+      cp -fr third_party/* ${CRAFT_PART_INSTALL}/third_party

--- a/huggingfaceserver-cpu/rockcraft.yaml
+++ b/huggingfaceserver-cpu/rockcraft.yaml
@@ -40,9 +40,6 @@ parts:
     source-subdir: python
     source-tag: v0.15.2
     build-packages:
-      - python3.10
-      - python3.10-venv
-      - python3.10-dev
       - build-essential
       - gcc-12
       - g++-12

--- a/huggingfaceserver-cpu/tests/test_rock.py
+++ b/huggingfaceserver-cpu/tests/test_rock.py
@@ -1,10 +1,11 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 import random
 import pytest
 import string
 import subprocess
+import shlex
 
 from charmed_kubeflow_chisme.rock import CheckRock
 
@@ -17,40 +18,22 @@ def test_rock():
     rock_version = check_rock.get_version()
     LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
 
-    # assert we have the expected files
-    subprocess.run(
-        [
-            "docker",
-            "run",
-            "--entrypoint",
-            "/bin/bash",
-            LOCAL_ROCK_IMAGE,
-            "-c",
-            "ls -la /usr/local/lib/python3.10/dist-packages/huggingfaceserver",
-        ],
-        check=True,
-    )
-    subprocess.run(
-        [
-            "docker",
-            "run",
-            "--entrypoint",
-            "/bin/bash",
-            LOCAL_ROCK_IMAGE,
-            "-c",
-            "ls -la /usr/local/lib/python3.10/dist-packages/kserve",
-        ],
-        check=True,
-    )
-    subprocess.run(
-        [
-            "docker",
-            "run",
-            "--entrypoint",
-            "/bin/bash",
-            LOCAL_ROCK_IMAGE,
-            "-c",
-            "ls -la /third_party",
-        ],
-        check=True,
-    )
+    paths = [
+        "/usr/local/lib/python3.10/dist-packages/huggingfaceserver",
+        "/usr/local/lib/python3.10/dist-packages/kserve",
+        "/third_party",
+    ]
+
+    for p in paths:
+        subprocess.run(
+            [
+                "docker",
+                "run",
+                "--entrypoint",
+                "/bin/bash",
+                LOCAL_ROCK_IMAGE,
+                "-c",
+                f"ls -la {shlex.quote(p)}",
+            ],
+            check=True,
+        )

--- a/huggingfaceserver-cpu/tests/test_rock.py
+++ b/huggingfaceserver-cpu/tests/test_rock.py
@@ -1,0 +1,56 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import random
+import pytest
+import string
+import subprocess
+
+from charmed_kubeflow_chisme.rock import CheckRock
+
+
+@pytest.mark.abort_on_fail
+def test_rock():
+    """Test rock."""
+    check_rock = CheckRock("rockcraft.yaml")
+    rock_image = check_rock.get_name()
+    rock_version = check_rock.get_version()
+    LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
+
+    # assert we have the expected files
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /usr/local/lib/python3.10/dist-packages/huggingfaceserver",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /usr/local/lib/python3.10/dist-packages/kserve",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /third_party",
+        ],
+        check=True,
+    )

--- a/huggingfaceserver-cpu/tox.ini
+++ b/huggingfaceserver-cpu/tox.ini
@@ -1,0 +1,54 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+[tox]
+skipsdist = True
+skip_missing_interpreters = True
+envlist = pack, export-to-docker, sanity, integration
+
+[testenv]
+setenv =
+    PYTHONPATH={toxinidir}
+    PYTHONBREAKPOINT=ipdb.set_trace
+    CHARM_REPO=https://github.com/canonical/kserve-operators.git
+    CHARM_BRANCH=main
+    LOCAL_CHARM_DIR=charm_repo
+
+[testenv:pack]
+passenv = *
+allowlist_externals =
+    rockcraft
+commands =
+    rockcraft pack
+
+[testenv:export-to-docker]
+passenv = *
+allowlist_externals =
+    bash
+    rockcraft
+    yq
+commands =
+    # pack rock and export to docker
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval ".platforms | keys | .[0]" rockcraft.yaml) && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
+             DOCKER_IMAGE=$NAME:$VERSION && \
+             echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
+             rockcraft.skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+
+[testenv:sanity]
+passenv = *
+deps =
+    pytest
+    charmed-kubeflow-chisme
+commands =
+    # run rock tests
+    pytest -s -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
+
+[testenv:integration]
+passenv = *
+allowlist_externals =
+    echo
+commands =
+    # TODO: Implement integration tests here
+    echo "WARNING: This is a placeholder test - no test is implemented here."


### PR DESCRIPTION
Closes: https://github.com/canonical/kserve-rocks/issues/207

Implements the huggingface-server-cpu rock

### **Test1:** Comparison with upstream code
I have compared my build image (you can find at `misohu/huggingfaceserver-cpu:0.15-2`)  with the upstream image `docker pull kserve/huggingfaceserver:v0.15.2` (since v0.15.2 there is  cpu and gpu variant). The basic docker run test reports same logs.

### **Test2:** Kserve deployment test
I was able to run sample model from huggingface with the image without any problem. 

1. I have setup kubernetes 
2. I have deployed kserver with my built image `misohu/huggingfaceserver-cpu:0.15-2`
3. I have ctreated a kserve deployment with this 
```
apiVersion: serving.kserve.io/v1beta1
kind: InferenceService
metadata:
  name: hf-tiny-sentiment
spec:
  predictor:
    model:
      modelFormat:
        name: huggingface
      args:
        - --backend=huggingface
        - --model_id=sshleifer/tiny-distilroberta-base
        - --task=fill_mask
      resources:
        requests:
          cpu: 100m
          memory: 600Mi
        limits:
          cpu: "1"
          memory: 1Gi
```

The deployemnt is running with logs 
```
_daemon_@hf-tiny-sentiment-predictor-7f5db788d8-dchxx:/$ pebble logs
2025-10-13T07:24:54.641Z [huggingfaceserver] /usr/local/lib/python3.10/dist-packages/torch/cuda/__init__.py:61: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
2025-10-13T07:24:54.641Z [huggingfaceserver]   import pynvml  # type: ignore[import]
2025-10-13T07:25:00.842Z [huggingfaceserver] INFO 10-13 07:25:00 [importing.py:53] Triton module has been replaced with a placeholder.
2025-10-13T07:25:01.021Z [huggingfaceserver] /usr/local/lib/python3.10/dist-packages/intel_extension_for_pytorch/transformers/optimize.py:4: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
2025-10-13T07:25:01.021Z [huggingfaceserver]   import pkg_resources
2025-10-13T07:25:02.071Z [huggingfaceserver] INFO 10-13 07:25:02 [__init__.py:239] Automatically detected platform cpu.
2025-10-13T07:25:03.556Z [huggingfaceserver] 2025-10-13 07:25:03.556 16 kserve INFO [__main__.py:load_model():284] Loading encoder model for task 'fill_mask' in torch.float32
2025-10-13T07:25:05.520Z [huggingfaceserver] 2025-10-13 07:25:05.520 16 kserve INFO [encoder_model.py:load():183] Successfully loaded tokenizer
2025-10-13T07:25:07.568Z [huggingfaceserver] Some weights of the model checkpoint at sshleifer/tiny-distilroberta-base were not used when initializing RobertaForMaskedLM: ['roberta.pooler.dense.bias', 'roberta.pooler.dense.weight']
2025-10-13T07:25:07.568Z [huggingfaceserver] - This IS expected if you are initializing RobertaForMaskedLM from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).
2025-10-13T07:25:07.568Z [huggingfaceserver] - This IS NOT expected if you are initializing RobertaForMaskedLM from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).
2025-10-13T07:25:07.570Z [huggingfaceserver] 2025-10-13 07:25:07.570 16 kserve INFO [encoder_model.py:load():204] Successfully loaded huggingface model from path sshleifer/tiny-distilroberta-base
2025-10-13T07:25:07.570Z [huggingfaceserver] 2025-10-13 07:25:07.570 16 kserve INFO [model_server.py:register_model():402] Registering model: hf-tiny-sentiment
2025-10-13T07:25:07.571Z [huggingfaceserver] 2025-10-13 07:25:07.571 16 kserve INFO [model_server.py:setup_event_loop():282] Setting max asyncio worker threads as 24
2025-10-13T07:25:08.070Z [huggingfaceserver] 2025-10-13 07:25:08.070 16 kserve INFO [server.py:_register_endpoints():108] OpenAI endpoints registered
2025-10-13T07:25:08.070Z [huggingfaceserver] 2025-10-13 07:25:08.070 16 kserve INFO [server.py:start():161] Starting uvicorn with 1 workers
2025-10-13T07:25:08.161Z [huggingfaceserver] 2025-10-13 07:25:08.161 16 uvicorn.error INFO:     Started server process [16]
2025-10-13T07:25:08.161Z [huggingfaceserver] 2025-10-13 07:25:08.161 16 uvicorn.error INFO:     Waiting for application startup.
2025-10-13T07:25:08.164Z [huggingfaceserver] 2025-10-13 07:25:08.164 16 kserve INFO [server.py:start():70] Starting gRPC server with 4 workers
2025-10-13T07:25:08.164Z [huggingfaceserver] 2025-10-13 07:25:08.164 16 kserve INFO [server.py:start():71] Starting gRPC server on [::]:8081
2025-10-13T07:25:08.164Z [huggingfaceserver] 2025-10-13 07:25:08.164 16 uvicorn.error INFO:     Application startup complete.
2025-10-13T07:25:08.164Z [huggingfaceserver] 2025-10-13 07:25:08.164 16 uvicorn.error INFO:     Uvicorn running on http://0.0.0.0:8080 (Press CTRL+C to quit)
```

This reports no problems (model was ready).

**Note:** the `rock-ci-metadata.yaml` is empty as its new image which serves as an alternative to the gpu image which is used in serving runtimes file.