### PR TITLE
chore(pmmlserver): bump to v0.18.0

### DIFF
--- a/pmmlserver/rockcraft.yaml
+++ b/pmmlserver/rockcraft.yaml
@@ -1,4 +1,4 @@
-# Based on https://github.com/kserve/kserve/blob/v0.17.0/python/pmml.Dockerfile
+# Based on https://github.com/kserve/kserve/blob/v0.18.0/python/pmml.Dockerfile
 #
 # See ../CONTRIBUTING.md for more details about the patterns used in this rock.
 # This rock is implemented with some atypical patterns due to the nature of the upstream
@@ -6,7 +6,7 @@
 name: pmmlserver
 summary: Pmml server for Kserve deployments
 description: "Kserve Pmml server"
-version: "0.17.0"
+version: "0.18.0"
 license: Apache-2.0
 base: ubuntu@24.04
 platforms:
@@ -35,7 +35,7 @@ parts:
     plugin: nil
     source: https://github.com/kserve/kserve.git
     source-subdir: python
-    source-tag: v0.17.0
+    source-tag: v0.18.0
     build-packages:
     - python3.12
     - python3.12-venv


### PR DESCRIPTION
## Summary

Bumps `pmmlserver` from `0.17.0` to upstream `v0.18.0`.

## Upstream references

- Dockerfile:
  - old: https://github.com/kserve/kserve/blob/v0.17.0/python/pmml.Dockerfile
  - new: https://github.com/kserve/kserve/blob/v0.18.0/python/pmml.Dockerfile

## What the workflow did

- Generated an updated `pmmlserver/rockcraft.yaml` using `meta-llama/llama-4-maverick` via OpenRouter, in 1 attempt(s).
- Ran sanity tests on the CI worker: `tox -e pack`, `tox -e export-to-docker`, `tox -e sanity`.

---

This change was AI-generated by the `bump-rock` workflow in [canonical/kubeflow-ci](https://github.com/canonical/kubeflow-ci). Please review carefully before merging.
