### PR TITLE
[PRA-320] Add llm-d-inference-scheduler rock

### DIFF
--- a/llm-d-inference-scheduler/README.md
+++ b/llm-d-inference-scheduler/README.md
@@ -1,0 +1,38 @@
+## llm-d-inference-scheduler
+
+Canonical rock for the [llm-d](https://github.com/llm-d) inference scheduler
+("Endpoint Picker", `epp`) v0.4.0, built from the upstream
+[`Dockerfile.epp`](https://github.com/llm-d/llm-d-router/blob/v0.4.0/Dockerfile.epp).
+
+The image is a CGO build that links `libpython3.12` and a static HuggingFace
+tokenizers library, and ships a Python 3.12 runtime with the chat-completions
+dependencies (excluding `torch`) installed.
+
+### Exposed ports
+
+| Port | Purpose                  |
+| ---- | ------------------------ |
+| 9002 | gRPC                     |
+| 9003 | health                   |
+| 9090 | metrics                  |
+| 5557 | KV-Events ZMQ SUB socket |
+
+### Building
+
+> **Note:** Building this rock compiles the `epp` binary with CGO and downloads
+> the tokenizers static library and Python dependencies. This can take a while.
+
+```bash
+tox -e pack
+tox -e export-to-docker
+tox -e sanity
+```
+
+### Running
+
+The scheduler is the rock's entrypoint service; pass `epp` flags after the image
+name:
+
+```bash
+docker run --rm llm-d-inference-scheduler:0.4.0 --help
+```

--- a/llm-d-inference-scheduler/rock-ci-metadata.yaml
+++ b/llm-d-inference-scheduler/rock-ci-metadata.yaml
@@ -1,0 +1,1 @@
+integrations: []

--- a/llm-d-inference-scheduler/rockcraft.yaml
+++ b/llm-d-inference-scheduler/rockcraft.yaml
@@ -85,7 +85,7 @@ parts:
       # Pin the versions used by the upstream Dockerfile.epp.
       - KVCACHE_MANAGER_VERSION: "v0.3.2"
       - TOKENIZERS_VERSION: "v1.22.1"
-      - TARGETOS: "linux"
+      - TARGETOS: "linux:-linux"
       - TARGETARCH: "amd64"
     override-build: |
       set -eux
@@ -110,7 +110,7 @@ parts:
         ./llm-d-kv-cache-manager/pkg/preprocessing/chat_completions
 
       # HuggingFace tokenizer bindings (static lib) required by the CGO build.
-      # The RELEASE_VERSION must match the one used by the imported
+      # The TOKENIZERS_VERSION must match the one used by the imported
       # llm-d-kv-cache-manager version.
       mkdir -p lib
       curl -L "https://github.com/daulet/tokenizers/releases/download/${TOKENIZERS_VERSION}/libtokenizers.${TARGETOS}-${TARGETARCH}.tar.gz" \

--- a/llm-d-inference-scheduler/rockcraft.yaml
+++ b/llm-d-inference-scheduler/rockcraft.yaml
@@ -81,7 +81,6 @@ parts:
       - libstdc++6
       - libzmq5
       - python3.12
-      # - python3.12-dev
     build-environment:
       # Pin the versions used by the upstream Dockerfile.epp.
       - KVCACHE_MANAGER_VERSION: "v0.3.2"

--- a/llm-d-inference-scheduler/rockcraft.yaml
+++ b/llm-d-inference-scheduler/rockcraft.yaml
@@ -28,8 +28,7 @@ platforms:
 # /dev/shm tmpfs (which stays writable under a read-only root). PEBBLE_COPY_ONCE
 # seeds the relocated directory with the baked-in service layers on first start.
 # Runtime caches (HOME, HuggingFace) are pointed at /dev/shm for the same reason.
-# Remove the relocation once pebble no longer needs to always write state to
-# disk: https://github.com/canonical/pebble/issues/462.
+
 environment:
   PYTHONPATH: "/usr/local/lib/python3.12/site-packages:/usr/lib/python3.12/site-packages"
   PYTHON: "python3.12"
@@ -45,8 +44,6 @@ services:
     summary: "llm-d inference scheduler (epp) service"
     startup: enabled
     command: "app/epp [ dummy-arguments ]"
-    # working-dir: "/app"
-    # command: "/bin/bash /opt/pebble/epp.sh [ dummy-arguments ]"
     on-success: shutdown
     on-failure: shutdown
 
@@ -159,12 +156,3 @@ parts:
       ln -sf /usr/bin/python3.12 $CRAFT_PART_INSTALL/usr/bin/python
       
       rm -rf /root/.cache
-
-  # scripts:
-  #   plugin: dump
-  #   after: [epp]
-  #   source: .
-  #   organize:
-  #     bin/epp.sh: opt/pebble/epp.sh
-  #   stage:
-  #     - opt/pebble/epp.sh

--- a/llm-d-inference-scheduler/rockcraft.yaml
+++ b/llm-d-inference-scheduler/rockcraft.yaml
@@ -1,0 +1,144 @@
+# Based on https://github.com/llm-d/llm-d-router/blob/v0.4.0/Dockerfile.epp
+# See ../CONTRIBUTING.md for more details about the patterns used in this rock.
+#
+# This rock builds the llm-d "Endpoint Picker" (epp) inference scheduler binary.
+# Unlike a plain Go service, the upstream image is a CGO build that links
+# libpython3.12 and a static HuggingFace tokenizers library, and ships a Python
+# 3.12 runtime with the chat-completions dependencies installed at runtime.
+
+name: llm-d-inference-scheduler
+summary: llm-d inference scheduler (Endpoint Picker)
+description: "llm-d Endpoint Picker (epp) inference scheduler v0.4.0."
+version: "0.4.0"
+license: Apache-2.0
+base: ubuntu@24.04
+run-user: _daemon_
+
+platforms:
+  amd64:
+
+# Top-level env is written to the OCI config.Env. Keep paths fully expanded:
+# rockcraft forbids '$' interpolation here.
+environment:
+  PYTHONPATH: "/usr/local/lib/python3.12/site-packages:/usr/lib/python3.12/site-packages"
+  PYTHON: "python3.12"
+  HF_HOME: "/tmp/.cache"
+
+entrypoint-service: epp
+services:
+  epp:
+    override: replace
+    summary: "llm-d inference scheduler (epp) service"
+    startup: enabled
+    command: "/app/epp [ dummy-arguments ]"
+    on-success: shutdown
+    on-failure: shutdown
+
+parts:
+  security-team-requirement:
+    plugin: nil
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+      dpkg-query --root=${CRAFT_PROJECT_DIR}/../bundles/ubuntu-24.04/rootfs/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
+      > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
+
+  epp:
+    plugin: go
+    source: https://github.com/llm-d/llm-d-router
+    source-type: git
+    source-tag: v0.4.0
+    build-snaps:
+      - go/1.24/stable
+    build-packages:
+      - build-essential
+      - ca-certificates
+      - clang
+      - curl
+      - git
+      - libpython3.12-dev
+      - libzmq3-dev
+      - pkg-config
+      - python3-pip
+      - python3.12-dev
+    overlay-packages:
+      # Runtime libraries needed by the CGO binary and the Python runtime.
+      - ca-certificates
+      - libpython3.12t64
+      - libstdc++6
+      - libzmq5
+      - python3.12
+    build-environment:
+      # Pin the versions used by the upstream Dockerfile.epp.
+      - KVCACHE_MANAGER_VERSION: "v0.3.2"
+      - TOKENIZERS_VERSION: "v1.22.1"
+      - TARGETOS: "linux"
+      - TARGETARCH: "amd64"
+    override-build: |
+      set -eux
+
+      # Empty the build directory and copy in the files referenced by the
+      # upstream Dockerfile (mirrors the COPY steps).
+      rm -rf ./*
+      cp $CRAFT_PART_SRC/go.mod $CRAFT_PART_SRC/go.sum ./
+      cp -r $CRAFT_PART_SRC/cmd ./cmd
+      cp -r $CRAFT_PART_SRC/pkg ./pkg
+      cp -r $CRAFT_PART_SRC/scripts ./scripts
+
+      go mod download
+
+      # Fetch the chat-completions Python requirements; these are installed into
+      # the final image and loaded at runtime by the KV-cache manager.
+      curl -L "https://raw.githubusercontent.com/llm-d/llm-d-kv-cache-manager/${KVCACHE_MANAGER_VERSION}/pkg/preprocessing/chat_completions/requirements.txt" \
+        -o ./requirements.txt
+
+      # Fetch the Python wrapper module shipped alongside the binary.
+      bash scripts/fetch-python-wrapper.sh "${KVCACHE_MANAGER_VERSION}" \
+        ./llm-d-kv-cache-manager/pkg/preprocessing/chat_completions
+
+      # HuggingFace tokenizer bindings (static lib) required by the CGO build.
+      # The RELEASE_VERSION must match the one used by the imported
+      # llm-d-kv-cache-manager version.
+      mkdir -p lib
+      curl -L "https://github.com/daulet/tokenizers/releases/download/${TOKENIZERS_VERSION}/libtokenizers.${TARGETOS}-${TARGETARCH}.tar.gz" \
+        | tar -xz -C lib
+      ranlib lib/*.a
+
+      # CGO build of the endpoint picker (epp), linking libpython3.12 and the
+      # static tokenizers library. python3.12-config supplies the Python
+      # compile/link flags.
+      export CGO_ENABLED=1
+      export GOOS="${TARGETOS}"
+      export GOARCH="${TARGETARCH}"
+      export CGO_CFLAGS="$(python3.12-config --cflags) -I$(pwd)/lib"
+      export CGO_LDFLAGS="$(python3.12-config --ldflags --embed) -L$(pwd)/lib -ltokenizers -ldl -lm"
+      go build -a -o bin/epp \
+        -ldflags="-extldflags '-L$(pwd)/lib'" \
+        cmd/epp/main.go
+
+      # Install the binary at the upstream runtime path (/app/epp).
+      mkdir -p $CRAFT_PART_INSTALL/app
+      cp bin/epp $CRAFT_PART_INSTALL/app/epp
+      chmod +x $CRAFT_PART_INSTALL/app/epp
+
+      # Install the Python runtime dependencies (excluding torch, like upstream)
+      # into the final image's site-packages.
+      SITE_PACKAGES=$CRAFT_PART_INSTALL/usr/local/lib/python3.12/site-packages
+      mkdir -p $SITE_PACKAGES
+      sed '/^torch\b/d' ./requirements.txt > ./requirements.notorch.txt
+      python3.12 -m pip install --no-cache-dir --break-system-packages \
+        --target $SITE_PACKAGES -r ./requirements.notorch.txt
+      python3.12 -m pip install --no-cache-dir --break-system-packages \
+        --target $SITE_PACKAGES PyYAML
+
+      # Install the wrapper module into site-packages.
+      cp ./llm-d-kv-cache-manager/pkg/preprocessing/chat_completions/render_jinja_template_wrapper.py \
+        $SITE_PACKAGES/
+
+      # python3.12 does not create the python3/python symlinks automatically;
+      # add them to mirror the upstream runtime image.
+      mkdir -p $CRAFT_PART_INSTALL/usr/bin
+      ln -sf /usr/bin/python3.12 $CRAFT_PART_INSTALL/usr/bin/python3
+      ln -sf /usr/bin/python3.12 $CRAFT_PART_INSTALL/usr/bin/python
+
+      rm -rf /root/.cache

--- a/llm-d-inference-scheduler/rockcraft.yaml
+++ b/llm-d-inference-scheduler/rockcraft.yaml
@@ -19,10 +19,24 @@ platforms:
 
 # Top-level env is written to the OCI config.Env. Keep paths fully expanded:
 # rockcraft forbids '$' interpolation here.
+#
+# KServe schedules this image with a read-only root filesystem
+# (securityContext.readOnlyRootFilesystem: true, see the
+# kserve-config-llm-scheduler LLMInferenceServiceConfig preset) and mounts no
+# writable volume. Pebble must create its control socket, state file and
+# identity key at runtime, so its data directory is relocated onto the writable
+# /dev/shm tmpfs (which stays writable under a read-only root). PEBBLE_COPY_ONCE
+# seeds the relocated directory with the baked-in service layers on first start.
+# Runtime caches (HOME, HuggingFace) are pointed at /dev/shm for the same reason.
+# Remove the relocation once pebble no longer needs to always write state to
+# disk: https://github.com/canonical/pebble/issues/462.
 environment:
   PYTHONPATH: "/usr/local/lib/python3.12/site-packages:/usr/lib/python3.12/site-packages"
   PYTHON: "python3.12"
-  HF_HOME: "/tmp/.cache"
+  HF_HOME: "/dev/shm/.cache/huggingface"
+  HOME: "/dev/shm"
+  PEBBLE: "/dev/shm/.pebble"
+  PEBBLE_COPY_ONCE: "/var/lib/pebble/default"
 
 entrypoint-service: epp
 services:
@@ -30,7 +44,9 @@ services:
     override: replace
     summary: "llm-d inference scheduler (epp) service"
     startup: enabled
-    command: "/app/epp [ dummy-arguments ]"
+    command: "app/epp [ dummy-arguments ]"
+    # working-dir: "/app"
+    # command: "/bin/bash /opt/pebble/epp.sh [ dummy-arguments ]"
     on-success: shutdown
     on-failure: shutdown
 
@@ -68,6 +84,7 @@ parts:
       - libstdc++6
       - libzmq5
       - python3.12
+      # - python3.12-dev
     build-environment:
       # Pin the versions used by the upstream Dockerfile.epp.
       - KVCACHE_MANAGER_VERSION: "v0.3.2"
@@ -140,5 +157,14 @@ parts:
       mkdir -p $CRAFT_PART_INSTALL/usr/bin
       ln -sf /usr/bin/python3.12 $CRAFT_PART_INSTALL/usr/bin/python3
       ln -sf /usr/bin/python3.12 $CRAFT_PART_INSTALL/usr/bin/python
-
+      
       rm -rf /root/.cache
+
+  # scripts:
+  #   plugin: dump
+  #   after: [epp]
+  #   source: .
+  #   organize:
+  #     bin/epp.sh: opt/pebble/epp.sh
+  #   stage:
+  #     - opt/pebble/epp.sh

--- a/llm-d-inference-scheduler/rockcraft.yaml
+++ b/llm-d-inference-scheduler/rockcraft.yaml
@@ -87,6 +87,8 @@ parts:
       - TOKENIZERS_VERSION: "v1.22.1"
       - TARGETOS: "linux"
       - TARGETARCH: "amd64"
+      - COMMIT_SHA: "86f5af75c31b7b6e4dbc8a2d1ed96fcf7c12d299" # on the original repo and branch run $(git rev-parse HEAD)
+      - BUILD_REF: "v0.4.0" # on the original repo and branch run $(git describe --abbrev=0)
     override-build: |
       set -eux
 
@@ -126,7 +128,7 @@ parts:
       export CGO_CFLAGS="$(python3.12-config --cflags) -I$(pwd)/lib"
       export CGO_LDFLAGS="$(python3.12-config --ldflags --embed) -L$(pwd)/lib -ltokenizers -ldl -lm"
       go build -a -o bin/epp \
-        -ldflags="-extldflags '-L$(pwd)/lib'" \
+        -ldflags="-extldflags '-L$(pwd)/lib' -X sigs.k8s.io/gateway-api-inference-extension/version.CommitSHA=${COMMIT_SHA} -X sigs.k8s.io/gateway-api-inference-extension/version.BuildRef=${BUILD_REF}" \
         cmd/epp/main.go
 
       # Install the binary at the upstream runtime path (/app/epp).

--- a/llm-d-inference-scheduler/rockcraft.yaml
+++ b/llm-d-inference-scheduler/rockcraft.yaml
@@ -85,7 +85,7 @@ parts:
       # Pin the versions used by the upstream Dockerfile.epp.
       - KVCACHE_MANAGER_VERSION: "v0.3.2"
       - TOKENIZERS_VERSION: "v1.22.1"
-      - TARGETOS: "linux:-linux"
+      - TARGETOS: "linux"
       - TARGETARCH: "amd64"
     override-build: |
       set -eux

--- a/llm-d-inference-scheduler/tests/test_rock.py
+++ b/llm-d-inference-scheduler/tests/test_rock.py
@@ -1,0 +1,85 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+import subprocess
+
+import pytest
+
+from charmed_kubeflow_chisme.rock import CheckRock
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+@pytest.fixture(scope="module")
+def rock_image() -> str:
+    """Return the local rock image reference (name:version)."""
+    check_rock = CheckRock("rockcraft.yaml")
+    return f"{check_rock.get_name()}:{check_rock.get_version()}"
+
+
+def _run_in_rock(rock_image: str, command: str) -> subprocess.CompletedProcess:
+    """Run a shell command inside the rock and return the completed process."""
+    return subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--entrypoint",
+            "/bin/bash",
+            rock_image,
+            "-c",
+            command,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.abort_on_fail
+def test_epp_binary_present(rock_image):
+    """The epp binary is installed at the upstream runtime path and executable."""
+    _run_in_rock(rock_image, "test -x /app/epp")
+
+
+@pytest.mark.abort_on_fail
+def test_python_wrapper_present(rock_image):
+    """The render_jinja_template_wrapper.py module is installed in site-packages."""
+    _run_in_rock(
+        rock_image,
+        "test -f /usr/local/lib/python3.12/site-packages/render_jinja_template_wrapper.py",
+    )
+
+
+@pytest.mark.abort_on_fail
+def test_epp_dynamic_libraries_resolve(rock_image):
+    """All shared libraries the CGO binary links against resolve inside the rock."""
+    result = _run_in_rock(rock_image, "ldd /app/epp")
+    logger.info("ldd /app/epp:\n%s", result.stdout)
+    assert "not found" not in result.stdout, (
+        f"Unresolved shared libraries in /app/epp:\n{result.stdout}"
+    )
+
+
+@pytest.mark.abort_on_fail
+def test_epp_runs(rock_image):
+    """The epp binary executes (loads its shared libs) and reports its usage."""
+    # `epp --help` exercises binary startup without requiring a running model
+    # server. argparse-style runners exit non-zero on --help, so tolerate the
+    # exit code and assert on the absence of a dynamic-linker failure instead.
+    result = subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            rock_image,
+            "--help",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    output = result.stdout + result.stderr
+    logger.info("epp --help output:\n%s", output)
+    assert "error while loading shared libraries" not in output, output

--- a/llm-d-inference-scheduler/tests/test_rock.py
+++ b/llm-d-inference-scheduler/tests/test_rock.py
@@ -18,18 +18,20 @@ def rock_image() -> str:
     return f"{check_rock.get_name()}:{check_rock.get_version()}"
 
 
-def _run_in_rock(rock_image: str, command: str) -> subprocess.CompletedProcess:
+def _run_in_rock(
+    rock_image: str, command: str, override_entrypoint: bool = True
+) -> subprocess.CompletedProcess:
     """Run a shell command inside the rock and return the completed process."""
     return subprocess.run(
         [
             "docker",
             "run",
             "--rm",
-            "--entrypoint",
-            "/bin/bash",
-            rock_image,
-            "-c",
-            command,
+            *(
+                ["--entrypoint", "/bin/bash", rock_image, "-c", command]
+                if override_entrypoint
+                else [rock_image, command]
+            ),
         ],
         check=True,
         capture_output=True,
@@ -68,17 +70,7 @@ def test_epp_runs(rock_image):
     # `epp --help` exercises binary startup without requiring a running model
     # server. argparse-style runners exit non-zero on --help, so tolerate the
     # exit code and assert on the absence of a dynamic-linker failure instead.
-    result = subprocess.run(
-        [
-            "docker",
-            "run",
-            "--rm",
-            rock_image,
-            "--help",
-        ],
-        capture_output=True,
-        text=True,
-    )
+    result = _run_in_rock(rock_image, "--help", override_entrypoint=False)
     output = result.stdout + result.stderr
     logger.info("epp --help output:\n%s", output)
     assert "error while loading shared libraries" not in output, output

--- a/llm-d-inference-scheduler/tests/test_rock.py
+++ b/llm-d-inference-scheduler/tests/test_rock.py
@@ -5,7 +5,6 @@ import logging
 import subprocess
 
 import pytest
-
 from charmed_kubeflow_chisme.rock import CheckRock
 
 logger = logging.getLogger(__name__)
@@ -58,9 +57,9 @@ def test_epp_dynamic_libraries_resolve(rock_image):
     """All shared libraries the CGO binary links against resolve inside the rock."""
     result = _run_in_rock(rock_image, "ldd /app/epp")
     logger.info("ldd /app/epp:\n%s", result.stdout)
-    assert "not found" not in result.stdout, (
-        f"Unresolved shared libraries in /app/epp:\n{result.stdout}"
-    )
+    assert (
+        "not found" not in result.stdout
+    ), f"Unresolved shared libraries in /app/epp:\n{result.stdout}"
 
 
 @pytest.mark.abort_on_fail

--- a/llm-d-inference-scheduler/tests/test_rock.py
+++ b/llm-d-inference-scheduler/tests/test_rock.py
@@ -40,7 +40,7 @@ def _run_in_rock(rock_image: str, command: str) -> subprocess.CompletedProcess:
 @pytest.mark.abort_on_fail
 def test_epp_binary_present(rock_image):
     """The epp binary is installed at the upstream runtime path and executable."""
-    _run_in_rock(rock_image, "test -x /app/epp")
+    _run_in_rock(rock_image, "test -x app/epp")
 
 
 @pytest.mark.abort_on_fail
@@ -55,11 +55,11 @@ def test_python_wrapper_present(rock_image):
 @pytest.mark.abort_on_fail
 def test_epp_dynamic_libraries_resolve(rock_image):
     """All shared libraries the CGO binary links against resolve inside the rock."""
-    result = _run_in_rock(rock_image, "ldd /app/epp")
-    logger.info("ldd /app/epp:\n%s", result.stdout)
+    result = _run_in_rock(rock_image, "ldd app/epp")
+    logger.info("ldd app/epp:\n%s", result.stdout)
     assert (
         "not found" not in result.stdout
-    ), f"Unresolved shared libraries in /app/epp:\n{result.stdout}"
+    ), f"Unresolved shared libraries in app/epp:\n{result.stdout}"
 
 
 @pytest.mark.abort_on_fail

--- a/llm-d-inference-scheduler/tox.ini
+++ b/llm-d-inference-scheduler/tox.ini
@@ -3,7 +3,7 @@
 [tox]
 skipsdist = True
 skip_missing_interpreters = True
-envlist = pack, export-to-docker, sanity, integration
+envlist = fmt, lint, pack, export-to-docker, sanity, integration
 
 [vars]
 tst_path = {toxinidir}/tests/

--- a/llm-d-inference-scheduler/tox.ini
+++ b/llm-d-inference-scheduler/tox.ini
@@ -1,0 +1,53 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+[tox]
+skipsdist = True
+skip_missing_interpreters = True
+envlist = pack, export-to-docker, sanity, integration
+
+[testenv]
+setenv =
+    PYTHONPATH={toxinidir}
+    PYTHONBREAKPOINT=ipdb.set_trace
+    CHARM_REPO=https://github.com/canonical/kserve-operators.git
+    CHARM_BRANCH=main
+    LOCAL_CHARM_DIR=charm_repo
+
+[testenv:pack]
+passenv = *
+allowlist_externals =
+    rockcraft
+commands =
+    rockcraft pack
+
+[testenv:export-to-docker]
+passenv = *
+allowlist_externals =
+    bash
+	rockcraft
+    yq
+commands =
+    # export rock to docker
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval ".platforms | keys | .[0]" rockcraft.yaml) && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
+             DOCKER_IMAGE=$NAME:$VERSION && \
+             echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
+             rockcraft.skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+
+[testenv:sanity]
+passenv = *
+deps =
+    pytest
+    charmed-kubeflow-chisme
+commands =
+    # run rock tests
+    pytest -s -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
+
+[testenv:integration]
+passenv = *
+allowlist_externals =
+    echo
+commands =
+    # TODO: Implement integration tests here

--- a/llm-d-inference-scheduler/tox.ini
+++ b/llm-d-inference-scheduler/tox.ini
@@ -5,6 +5,9 @@ skipsdist = True
 skip_missing_interpreters = True
 envlist = pack, export-to-docker, sanity, integration
 
+[vars]
+tst_path = {toxinidir}/tests/
+
 [testenv]
 setenv =
     PYTHONPATH={toxinidir}
@@ -12,6 +15,28 @@ setenv =
     CHARM_REPO=https://github.com/canonical/kserve-operators.git
     CHARM_BRANCH=main
     LOCAL_CHARM_DIR=charm_repo
+
+[testenv:fmt]
+deps =
+    isort
+    black
+commands =
+	isort {[vars]tst_path}
+	black {[vars]tst_path}
+description = Apply coding style standards to code
+skip_install = true
+
+[testenv:lint]
+deps =
+    flake8
+    isort
+    black
+commands =
+	flake8 --max-line-length 99 {[vars]tst_path}
+	isort --check-only --diff {[vars]tst_path}
+	black --check --diff {[vars]tst_path}
+description = Check code against coding style standards
+skip_install = true
 
 [testenv:pack]
 passenv = *


### PR DESCRIPTION
This PR introduce the `llm-d-inference-scheduler` v0.40.0.
The PR includes: 
- rockcraft.yaml 
- sanity tests
- README.md

The OCI image of this PR is published [here](ghcr.io/welpaolo/llm-d-inference-scheduler:0.4.0)

Tests on Kserve operators repository: https://github.com/canonical/kserve-operators/pull/493 

In order to test the image please follow the steps:
- clone the kserve-operators repository 
- checkout this branch [llmisvc-rewrite](https://github.com/canonical/kserve-operators/tree/llmisvc-rewrite)
- update the configuration file for kserve-images: https://github.com/canonical/kserve-operators/blob/llmisvc-rewrite/charms/kserve-llmisvc/src/default-custom-images.json by adding the new built image.
- Build the charms locally and run the `bundle-integration` tests with the following commands in the main repo folder:
```
tox -e bundle-integration -- --model kubeflow --keep-models --charms-path charms
```