### PR TITLE
[PRA-321] Add llm-d-routing-sidecar rock

### DIFF
--- a/llm-d-routing-sidecar/README.md
+++ b/llm-d-routing-sidecar/README.md
@@ -1,0 +1,25 @@
+## llm-d-routing-sidecar
+
+Canonical rock for the [llm-d](https://github.com/llm-d) routing sidecar
+(`pd-sidecar`) v0.4.0, built from the upstream
+[`Dockerfile.sidecar`](https://github.com/llm-d/llm-d-router/blob/v0.4.0/Dockerfile.sidecar).
+
+The sidecar is a plain Go build (CGO disabled) that ships a single static
+binary, installed at `/app/pd-sidecar`.
+
+### Building
+
+```bash
+tox -e pack
+tox -e export-to-docker
+tox -e sanity
+```
+
+### Running
+
+The sidecar is the rock's entrypoint service; pass `pd-sidecar` flags after the
+image name:
+
+```bash
+docker run --rm llm-d-routing-sidecar:0.4.0 --help
+```

--- a/llm-d-routing-sidecar/rock-ci-metadata.yaml
+++ b/llm-d-routing-sidecar/rock-ci-metadata.yaml
@@ -1,0 +1,1 @@
+integrations: []

--- a/llm-d-routing-sidecar/rockcraft.yaml
+++ b/llm-d-routing-sidecar/rockcraft.yaml
@@ -74,7 +74,3 @@ parts:
       mkdir -p $CRAFT_PART_INSTALL/app
       cp bin/pd-sidecar $CRAFT_PART_INSTALL/app/pd-sidecar
       chmod +x $CRAFT_PART_INSTALL/app/pd-sidecar
-
-      # Ship the third-party licenses in the final rock.
-      mkdir -p $CRAFT_PART_INSTALL/third_party
-      cp -r third_party $CRAFT_PART_INSTALL/third_party/

--- a/llm-d-routing-sidecar/rockcraft.yaml
+++ b/llm-d-routing-sidecar/rockcraft.yaml
@@ -1,0 +1,86 @@
+# Based on https://github.com/llm-d/llm-d-router/blob/v0.4.0/Dockerfile.sidecar
+# See ../CONTRIBUTING.md for more details about the patterns used in this rock.
+#
+# This rock builds the llm-d routing sidecar (pd-sidecar) binary. Unlike the
+# inference scheduler (epp), the sidecar is a plain Go build (CGO disabled) that
+# ships a single static binary, so this rock mirrors the kserve-router rock.
+
+name: llm-d-routing-sidecar
+summary: llm-d routing sidecar (pd-sidecar)
+description: "llm-d routing sidecar (pd-sidecar) v0.4.0."
+version: "0.4.0"
+license: Apache-2.0
+base: ubuntu@24.04
+run-user: _daemon_
+
+platforms:
+  amd64:
+
+entrypoint-service: routing-sidecar
+services:
+  routing-sidecar:
+    override: replace
+    summary: "llm-d routing sidecar (pd-sidecar) service"
+    startup: enabled
+    command: "/app/pd-sidecar [ dummy-arguments ]"
+    on-success: shutdown
+    on-failure: shutdown
+
+parts:
+  security-team-requirement:
+    plugin: nil
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+      dpkg-query --root=${CRAFT_PROJECT_DIR}/../bundles/ubuntu-24.04/rootfs/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
+      > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
+
+  routing-sidecar:
+    plugin: go
+    source: https://github.com/llm-d/llm-d-router
+    source-type: git
+    source-tag: v0.4.0
+    build-snaps:
+      - go/1.24/stable
+    build-environment:
+      # Plain Go build, mirroring the upstream Dockerfile.sidecar.
+      - CGO_ENABLED: 0
+      - GOOS: linux
+      - GOARCH: amd64
+      - COMMIT_SHA: unknown
+      - BUILD_REF: v0.4.0
+    override-build: |
+      set -eux
+
+      # Empty the build directory and copy in the files referenced by the
+      # upstream Dockerfile (mirrors the COPY steps).
+      rm -rf ./*
+      cp $CRAFT_PART_SRC/go.mod $CRAFT_PART_SRC/go.sum ./
+
+      go mod download
+
+      # The upstream Dockerfile copies cmd/pd-sidecar/main.go to cmd/cmd.go.
+      mkdir -p cmd pkg
+      cp $CRAFT_PART_SRC/cmd/pd-sidecar/main.go cmd/cmd.go
+      cp -r $CRAFT_PART_SRC/pkg/sidecar pkg/sidecar
+      cp -r $CRAFT_PART_SRC/pkg/common pkg/common
+
+      # Build the routing sidecar binary with the upstream version stamps.
+      go build -a -o bin/pd-sidecar \
+        -ldflags="-X github.com/llm-d/llm-d-inference-scheduler/pkg/sidecar/version.CommitSHA=${COMMIT_SHA} -X github.com/llm-d/llm-d-inference-scheduler/pkg/sidecar/version.BuildRef=${BUILD_REF}" \
+        cmd/cmd.go
+
+      # Generate third-party licenses.
+      cp -r $CRAFT_PART_SRC/LICENSE ./LICENSE
+      go install github.com/google/go-licenses@latest
+      $GOBIN/go-licenses check ./cmd/... ./pkg/... --disallowed_types="forbidden,unknown"
+      $GOBIN/go-licenses save --save_path third_party/library ./cmd
+
+      # Install the binary at the upstream runtime path (/app/pd-sidecar).
+      mkdir -p $CRAFT_PART_INSTALL/app
+      cp bin/pd-sidecar $CRAFT_PART_INSTALL/app/pd-sidecar
+      chmod +x $CRAFT_PART_INSTALL/app/pd-sidecar
+
+      # Ship the third-party licenses in the final rock.
+      mkdir -p $CRAFT_PART_INSTALL/third_party
+      cp -r third_party $CRAFT_PART_INSTALL/third_party/

--- a/llm-d-routing-sidecar/rockcraft.yaml
+++ b/llm-d-routing-sidecar/rockcraft.yaml
@@ -47,8 +47,8 @@ parts:
       - CGO_ENABLED: 0
       - GOOS: linux
       - GOARCH: amd64
-      - COMMIT_SHA: unknown
-      - BUILD_REF: v0.4.0
+      - COMMIT_SHA: "86f5af75c31b7b6e4dbc8a2d1ed96fcf7c12d299" # on the original repo and branch run $(git rev-parse HEAD)
+      - BUILD_REF: v0.4.0 # on the original repo and branch run $(git describe --abbrev=0)
     override-build: |
       set -eux
 
@@ -69,12 +69,6 @@ parts:
       go build -a -o bin/pd-sidecar \
         -ldflags="-X github.com/llm-d/llm-d-inference-scheduler/pkg/sidecar/version.CommitSHA=${COMMIT_SHA} -X github.com/llm-d/llm-d-inference-scheduler/pkg/sidecar/version.BuildRef=${BUILD_REF}" \
         cmd/cmd.go
-
-      # Generate third-party licenses.
-      cp -r $CRAFT_PART_SRC/LICENSE ./LICENSE
-      go install github.com/google/go-licenses@latest
-      $GOBIN/go-licenses check ./cmd/... ./pkg/... --disallowed_types="forbidden,unknown"
-      $GOBIN/go-licenses save --save_path third_party/library ./cmd
 
       # Install the binary at the upstream runtime path (/app/pd-sidecar).
       mkdir -p $CRAFT_PART_INSTALL/app

--- a/llm-d-routing-sidecar/tests/test_rock.py
+++ b/llm-d-routing-sidecar/tests/test_rock.py
@@ -29,17 +29,3 @@ def test_rock():
         ],
         check=True,
     )
-
-    subprocess.run(
-        [
-            "docker",
-            "run",
-            "--rm",
-            "--entrypoint",
-            "/bin/bash",
-            LOCAL_ROCK_IMAGE,
-            "-c",
-            "ls -la /third_party",
-        ],
-        check=True,
-    )

--- a/llm-d-routing-sidecar/tests/test_rock.py
+++ b/llm-d-routing-sidecar/tests/test_rock.py
@@ -1,9 +1,9 @@
 # Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import pytest
 import subprocess
 
+import pytest
 from charmed_kubeflow_chisme.rock import CheckRock
 
 

--- a/llm-d-routing-sidecar/tests/test_rock.py
+++ b/llm-d-routing-sidecar/tests/test_rock.py
@@ -1,0 +1,45 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import pytest
+import subprocess
+
+from charmed_kubeflow_chisme.rock import CheckRock
+
+
+@pytest.mark.abort_on_fail
+def test_rock():
+    """Test rock."""
+    check_rock = CheckRock("rockcraft.yaml")
+    rock_image = check_rock.get_name()
+    rock_version = check_rock.get_version()
+    LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
+
+    # assert the rock contains the expected files
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /app/pd-sidecar",
+        ],
+        check=True,
+    )
+
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--entrypoint",
+            "/bin/bash",
+            LOCAL_ROCK_IMAGE,
+            "-c",
+            "ls -la /third_party",
+        ],
+        check=True,
+    )

--- a/llm-d-routing-sidecar/tox.ini
+++ b/llm-d-routing-sidecar/tox.ini
@@ -3,7 +3,10 @@
 [tox]
 skipsdist = True
 skip_missing_interpreters = True
-envlist = pack, export-to-docker, sanity, integration
+envlist = fmt, lint, pack, export-to-docker, sanity, integration
+
+[vars]
+tst_path = {toxinidir}/tests/
 
 [testenv]
 setenv =
@@ -12,6 +15,28 @@ setenv =
     CHARM_REPO=https://github.com/canonical/kserve-operators.git
     CHARM_BRANCH=main
     LOCAL_CHARM_DIR=charm_repo
+
+[testenv:fmt]
+deps =
+    isort
+    black
+commands =
+	isort {[vars]tst_path}
+	black {[vars]tst_path}
+description = Apply coding style standards to code
+skip_install = true
+
+[testenv:lint]
+deps =
+    flake8
+    isort
+    black
+commands =
+	flake8 --max-line-length 99 {[vars]tst_path}
+	isort --check-only --diff {[vars]tst_path}
+	black --check --diff {[vars]tst_path}
+description = Check code against coding style standards
+skip_install = true
 
 [testenv:pack]
 passenv = *
@@ -44,3 +69,10 @@ deps =
 commands =
     # run rock tests
     pytest -s -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
+
+[testenv:integration]
+passenv = *
+allowlist_externals =
+    echo
+commands =
+    # TODO: Implement integration tests here

--- a/llm-d-routing-sidecar/tox.ini
+++ b/llm-d-routing-sidecar/tox.ini
@@ -1,0 +1,46 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+[tox]
+skipsdist = True
+skip_missing_interpreters = True
+envlist = pack, export-to-docker, sanity, integration
+
+[testenv]
+setenv =
+    PYTHONPATH={toxinidir}
+    PYTHONBREAKPOINT=ipdb.set_trace
+    CHARM_REPO=https://github.com/canonical/kserve-operators.git
+    CHARM_BRANCH=main
+    LOCAL_CHARM_DIR=charm_repo
+
+[testenv:pack]
+passenv = *
+allowlist_externals =
+    rockcraft
+commands =
+    rockcraft pack
+
+[testenv:export-to-docker]
+passenv = *
+allowlist_externals =
+    bash
+	rockcraft
+    yq
+commands =
+    # export rock to docker
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval ".platforms | keys | .[0]" rockcraft.yaml) && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
+             DOCKER_IMAGE=$NAME:$VERSION && \
+             echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
+             rockcraft.skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+
+[testenv:sanity]
+passenv = *
+deps =
+    pytest
+    charmed-kubeflow-chisme
+commands =
+    # run rock tests
+    pytest -s -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests


### PR DESCRIPTION
This PR adds:
- rockcraft.yaml
- sanity checks
- README.md

The OCI image of this PR is published [here](ghcr.io/welpaolo/llm-d-routing-sidecar:0.4.0)

Tests on Kserve operators repository: https://github.com/canonical/kserve-operators/pull/493 

In order to test the image please follow the steps:
- clone the kserve-operators repository 
- checkout this branch [llmisvc-rewrite](https://github.com/canonical/kserve-operators/tree/llmisvc-rewrite)
- update the configuration file for kserve-images: https://github.com/canonical/kserve-operators/blob/llmisvc-rewrite/charms/kserve-llmisvc/src/default-custom-images.json by adding the new built image.
- Build the charms locally and run the `bundle-integration` tests with the following commands in the main repo folder:
```
tox -e bundle-integration -- --model kubeflow --keep-models --charms-path charms
```