### PR TITLE
feat: implement llmisvc controller rock

### DIFF
--- a/llmisvc-controller/rock-ci-metadata.yaml
+++ b/llmisvc-controller/rock-ci-metadata.yaml
@@ -1,0 +1,1 @@
+integrations: []

--- a/llmisvc-controller/rockcraft.yaml
+++ b/llmisvc-controller/rockcraft.yaml
@@ -1,0 +1,52 @@
+# Based on https://github.com/kserve/kserve/blob/v0.17.0/llmisvc-controller.Dockerfile
+name: kserve-llmisvc-controller
+summary: KServe LLMISVC controller
+description: "KServe LLMInferenceService controller"
+version: "0.17.0"
+license: Apache-2.0
+base: ubuntu@22.04
+platforms:
+    amd64:
+run-user: _daemon_
+
+services:
+  llmisvc-controller:
+    override: replace
+    summary: "KServe LLMISVC controller service"
+    startup: enabled
+    command: "/manager"
+
+parts:
+  security-team-requirement:
+    plugin: nil
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+      dpkg-query --root=${CRAFT_PROJECT_DIR}/../bundles/ubuntu-22.04/rootfs/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
+      > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
+
+  llmisvc-controller:
+    plugin: go
+    source: https://github.com/kserve/kserve
+    source-type: git
+    source-tag: v0.17.0
+    build-snaps:
+      - go/1.25/stable
+    build-environment:
+      - CGO_ENABLED: "0"
+      - GOOS: linux
+    override-build: |
+      go mod download
+
+      # Build
+      go build -a -o manager ./cmd/llmisvc
+
+      # Generate third-party licenses
+      cp -r $CRAFT_PART_SRC/LICENSE ./LICENSE
+      go install github.com/google/go-licenses@latest
+      $GOBIN/go-licenses check ./cmd/... ./pkg/... --disallowed_types="forbidden,unknown"
+      $GOBIN/go-licenses save --save_path third_party/library ./cmd/llmisvc
+
+      # Copy the files to the install directory
+      cp -r third_party $CRAFT_PART_INSTALL/third_party
+      cp -r manager $CRAFT_PART_INSTALL/manager

--- a/llmisvc-controller/tests/test_rock.py
+++ b/llmisvc-controller/tests/test_rock.py
@@ -1,0 +1,36 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import pytest
+import subprocess
+
+from charmed_kubeflow_chisme.rock import CheckRock
+
+
+@pytest.mark.abort_on_fail
+def test_rock():
+    """Test rock."""
+    check_rock = CheckRock("rockcraft.yaml")
+    rock_image = check_rock.get_name()
+    rock_version = check_rock.get_version()
+    LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
+
+    # assert the rock contains the expected files
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            LOCAL_ROCK_IMAGE,
+            "exec",
+            "ls",
+            "-la",
+            "/third_party",
+        ],
+        check=True,
+    )
+
+    subprocess.run(
+        ["docker", "run", "--rm", LOCAL_ROCK_IMAGE, "exec", "ls", "-la", "/manager"],
+        check=True,
+    )

--- a/llmisvc-controller/tox.ini
+++ b/llmisvc-controller/tox.ini
@@ -1,0 +1,54 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+[tox]
+skipsdist = True
+skip_missing_interpreters = True
+envlist = pack, export-to-docker, sanity, integration
+
+[testenv]
+setenv =
+    PYTHONPATH={toxinidir}
+    PYTHONBREAKPOINT=ipdb.set_trace
+    CHARM_REPO=https://github.com/canonical/kserve-operators.git
+    CHARM_BRANCH=main
+    LOCAL_CHARM_DIR=charm_repo
+
+[testenv:pack]
+passenv = *
+allowlist_externals =
+    rockcraft
+commands =
+    rockcraft pack
+
+[testenv:export-to-docker]
+passenv = *
+allowlist_externals =
+    bash
+    rockcraft
+    yq
+commands =
+    # export rock to docker
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval ".platforms | keys | .[0]" rockcraft.yaml) && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
+             DOCKER_IMAGE=$NAME:$VERSION && \
+             echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
+             rockcraft.skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+
+[testenv:sanity]
+passenv = *
+deps =
+    pytest
+    charmed-kubeflow-chisme
+commands =
+    # run rock tests
+    pytest -s -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
+
+[testenv:integration]
+passenv = *
+allowlist_externals =
+    echo
+commands =
+    # TODO: Implement integration tests here
+    echo "WARNING: This is a placeholder test - no test is implemented here."


### PR DESCRIPTION
# Add rock for KServe LLMISVC controller

## Summary

Adds a new rock for the KServe LLMInferenceService (LLMISVC) controller, based on the upstream `llmisvc-controller.Dockerfile` at kserve v0.17.0. Follows the same conventions as the existing `controller` rock.

## Changes

- `llmisvc-controller/rockcraft.yaml` — builds `./cmd/llmisvc` from kserve v0.17.0 with Go 1.25, generates third-party licenses, and runs `/manager` as a pebble service.
- `llmisvc-controller/rock-ci-metadata.yaml` — CI metadata with `integrations: []` (no consumer charm in kserve-operators yet).
- `llmisvc-controller/tox.ini` — pack, export-to-docker, sanity, and integration test envs.
- `llmisvc-controller/tests/test_rock.py` — sanity test asserting `/manager` and `/third_party` exist in the rock.

## Notes

- No `ReadOnlyRootFilesystem` patch is applied — unlike the `controller` rock, the llmisvc build path does not include the `inferencegraph` sources that patch targets.
- Integrations are intentionally left empty until a consumer charm/resource exists in `canonical/kserve-operators`.

## Testing

Here is my published test rock: `misohu/kserve-llmisvc-controller:0.17.0-2` which i have used locally as part of this [test](https://github.com/canonical/kserve-operators/pull/517) branch in kserve-operators. All integration tests were passing 
