### PR TITLE
feat: update rock-ci-metadata.yaml for vllm-cpu

### DIFF
--- a/vllm-cpu/rock-ci-metadata.yaml
+++ b/vllm-cpu/rock-ci-metadata.yaml
@@ -1,1 +1,6 @@
-integrations: []
+integrations:
+  - consumer-repository: https://github.com/canonical/kserve-operators.git
+
+    replace-image:
+      - file: charms/kserve-llmisvc/src/default-custom-images.json
+        path: vllm


### PR DESCRIPTION
Update rock-ci-metadata.yaml to integrate the vllm-cpu rock correctly.