### PR TITLE
feat: update rock-ci-metadata.yaml for llm-d-routing

### DIFF
--- a/llm-d-routing-sidecar/rock-ci-metadata.yaml
+++ b/llm-d-routing-sidecar/rock-ci-metadata.yaml
@@ -1,1 +1,6 @@
-integrations: []
+integrations:
+  - consumer-repository: https://github.com/canonical/kserve-operators.git
+
+    replace-image:
+      - file: charms/kserve-llmisvc/src/default-custom-images.json
+        path: llm_routing_sidecar


### PR DESCRIPTION
Update rock-ci-metadata.yaml to integrate the llm-d-routing rock correctly.