### PR TITLE
feat: update rock-ci-metadata.yaml for llm-d-scheduler

### DIFF
--- a/llm-d-inference-scheduler/rock-ci-metadata.yaml
+++ b/llm-d-inference-scheduler/rock-ci-metadata.yaml
@@ -1,1 +1,6 @@
-integrations: []
+integrations:
+  - consumer-repository: https://github.com/canonical/kserve-operators.git
+
+    replace-image:
+      - file: charms/kserve-llmisvc/src/default-custom-images.json
+        path: llm_scheduler


### PR DESCRIPTION
Update rock-ci-metadata.yaml to integrate the llm-d-scheduler rock correctly.