### PR TITLE
feat: update rock-ci-metadata.yaml for llmisvc-controller-metadata

### DIFF
--- a/llmisvc-controller/rock-ci-metadata.yaml
+++ b/llmisvc-controller/rock-ci-metadata.yaml
@@ -1,1 +1,6 @@
-integrations: []
+integrations:
+  - consumer-repository: https://github.com/canonical/kserve-operators.git
+
+    replace-image:
+      - file: charms/kserve-llmisvc/metadata.yaml
+        path: resources.llmisvc-controller-image.upstream-source


### PR DESCRIPTION
Update rock-ci-metadata.yaml to integrate the llmisvc-controller-metadata rock correctly.