### PR TITLE
fix: add missing vllm runtime dependencies

### DIFF
--- a/huggingfaceserver/rockcraft.yaml
+++ b/huggingfaceserver/rockcraft.yaml
@@ -75,6 +75,14 @@ parts:
       - libibverbs-dev
       # Ship a system Python in the final image
       - python3.12
+      # Python + C development headers for runtime JIT compilation.
+      # vLLM's torch.compile/Triton path compiles a CPython extension
+      # (cuda_utils.cpython-312-*.so) at runtime with gcc, which needs the
+      # standard C headers (stdlib.h, via libc6-dev) and Python.h (via
+      # libpython3.12-dev). python3.12-dev pulls in both. Without them the
+      # engine crashes with "fatal error: stdlib.h: No such file or directory".
+      # Mirrors the upstream prod image, which installs python3.12-dev.
+      - python3.12-dev
     build-packages:
       - build-essential
       - wget


### PR DESCRIPTION
resolves https://github.com/canonical/kserve-rocks/issues/254

## What Was the Problem?

The `gcc` subprocess started by PyTorch failed because some dependencies PyTorch relies on (including `gcc` itself) were missing at runtime.

## How Were the Changes Tested?

### Instructions

On the source of this branch, the instructions of the rock's README were followed but the InferenceService of the target issue (with modified model args to avoid out-of-memory issues) was employed in place of the README's one:

<details> 

```
ubuntu@beldam:~$ kubectl apply -f - <<EOF
apiVersion: "serving.kserve.io/v1beta1"
kind: "InferenceService"
metadata:
  name: "qwen25-3b-native"
  annotations:
    sidecar.istio.io/inject: 'false'
  labels:
    serving.kserve.io/inferenceservice: "qwen25-3b-native"
spec:
  predictor:
    minReplicas: 1
    maxReplicas: 3
    model:
      modelFormat:
        name: huggingface
      storageUri: "hf://Qwen/Qwen2.5-3B-Instruct"
      args:
        - "--max-model-len"
        - "32768"  # Qwen 2.5 supports up to 128k, but 32k or lower keeps VRAM allocation stable
        - "--gpu-memory-utilization"
        - "0.85"  # was 0.90 — frees ~2 GiB headroom per GPU
        - "--max-num-seqs"
        - "64"  # was 256 — shrinks the warmup logits.sort() ~4x
      resources:
        limits:
          cpu: "4"
          memory: 16Gi
          nvidia.com/gpu: "1"
        requests:
          cpu: "2"
          memory: 8Gi
          nvidia.com/gpu: "1"
EOF
inferenceservice.serving.kserve.io/qwen25-3b-native created
```

</details>

### Results

The logs of the KServe container of the `InferenceService` no longer show the errors of the issue but a successful start-up:

<details>

```
ubuntu@beldam:~$ kubectl exec pods/qwen25-3b-native-predictor-00001-deployment-64ccdfd9d5-x9xsw -- pebble logs -n 1000 -f
Defaulted container "kserve-container" out of: kserve-container, queue-proxy, storage-initializer (init)
2026-07-29T19:45:50.051Z [huggingfaceserver] [2026-07-29 19:45:50] INFO kserve_storage.py:161: Copying contents of /mnt/models to local
2026-07-29T19:45:50.051Z [huggingfaceserver] [2026-07-29 19:45:50] INFO kserve_storage.py:229: Successfully copied /mnt/models to None
2026-07-29T19:45:50.051Z [huggingfaceserver] [2026-07-29 19:45:50] INFO kserve_storage.py:230: Model downloaded in 0.0004202070012979675 seconds.
2026-07-29T19:45:50.109Z [huggingfaceserver] WARNING 07-29 19:45:50 [argparse_utils.py:82] argument 'disable_log_requests' is deprecated
2026-07-29T19:45:50.109Z [huggingfaceserver] [2026-07-29 19:45:50] INFO kserve_storage.py:161: Copying contents of /mnt/models to local
2026-07-29T19:45:50.109Z [huggingfaceserver] [2026-07-29 19:45:50] INFO kserve_storage.py:229: Successfully copied /mnt/models to None
2026-07-29T19:45:50.109Z [huggingfaceserver] [2026-07-29 19:45:50] INFO kserve_storage.py:230: Model downloaded in 0.00012996900113648735 seconds.
2026-07-29T19:45:50.233Z [huggingfaceserver] [2026-07-29 19:45:50] INFO model_server.py:423: Registering model: qwen25-3b-native
2026-07-29T19:45:50.234Z [huggingfaceserver] [2026-07-29 19:45:50] INFO model_server.py:301: Setting max asyncio worker threads as 32
2026-07-29T19:46:09.480Z [huggingfaceserver] INFO 07-29 19:46:09 [model.py:541] Resolved architecture: Qwen2ForCausalLM
2026-07-29T19:46:09.480Z [huggingfaceserver] WARNING 07-29 19:46:09 [model.py:1833] Your device 'Tesla T4' (with compute capability 7.5) doesn't support torch.bfloat16. Falling back to torch.float16 for compatibility.
2026-07-29T19:46:09.480Z [huggingfaceserver] WARNING 07-29 19:46:09 [model.py:1885] Casting torch.bfloat16 to torch.float16.
2026-07-29T19:46:09.480Z [huggingfaceserver] INFO 07-29 19:46:09 [model.py:1561] Using max model len 32768
2026-07-29T19:46:09.801Z [huggingfaceserver] INFO 07-29 19:46:09 [scheduler.py:226] Chunked prefill is enabled with max_num_batched_tokens=2048.
2026-07-29T19:46:09.802Z [huggingfaceserver] INFO 07-29 19:46:09 [vllm.py:624] Asynchronous scheduling is enabled.
2026-07-29T19:46:22.889Z [huggingfaceserver] (EngineCore_DP0 pid=257) INFO 07-29 19:46:22 [core.py:96] Initializing a V1 LLM engine (v0.15.1) with config: model='/mnt/models', speculative_config=None, tokenizer='/mnt/models', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.float16, max_seq_len=32768, download_dir=None, load_format=auto, tensor_parallel_size=2, pipeline_parallel_size=1, data_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=/mnt/models, enable_prefix_caching=True, enable_chunked_prefill=True, pooler_config=None, compilation_config={'level': None, 'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'splitting_ops': ['vllm::unified_attention', 'vllm::unified_attention_with_output', 'vllm::unified_mla_attention', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::gdn_attention_core', 'vllm::kda_attention', 'vllm::sparse_attn_indexer', 'vllm::rocm_aiter_sparse_attn_indexer', 'vllm::unified_kv_cache_update'], 'compile_mm_encoder': False, 'compile_sizes': [], 'compile_ranges_split_points': [2048], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'eliminate_noops': True, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False}, 'max_cudagraph_capture_size': 128, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': True}, 'local_cache_dir': None, 'static_all_moe_layers': []}
2026-07-29T19:46:22.889Z [huggingfaceserver] (EngineCore_DP0 pid=257) WARNING 07-29 19:46:22 [multiproc_executor.py:910] Reducing Torch parallelism from 40 threads to 1 to avoid unnecessary CPU contention. Set OMP_NUM_THREADS in the external environment to tune this value as needed.
2026-07-29T19:46:39.552Z [huggingfaceserver] INFO 07-29 19:46:39 [parallel_state.py:1212] world_size=2 rank=1 local_rank=1 distributed_init_method=tcp://127.0.0.1:42241 backend=nccl
2026-07-29T19:46:39.569Z [huggingfaceserver] INFO 07-29 19:46:39 [parallel_state.py:1212] world_size=2 rank=0 local_rank=0 distributed_init_method=tcp://127.0.0.1:42241 backend=nccl
2026-07-29T19:46:40.312Z [huggingfaceserver] INFO 07-29 19:46:40 [nccl.py:24] Found nccl from environment variable VLLM_NCCL_SO_PATH=/usr/local/lib/python3.12/dist-packages/nvidia/nccl/lib/libnccl.so.2
2026-07-29T19:46:40.312Z [huggingfaceserver] INFO 07-29 19:46:40 [nccl.py:24] Found nccl from environment variable VLLM_NCCL_SO_PATH=/usr/local/lib/python3.12/dist-packages/nvidia/nccl/lib/libnccl.so.2
2026-07-29T19:46:40.312Z [huggingfaceserver] INFO 07-29 19:46:40 [pynccl.py:111] vLLM is using nccl==2.27.5
2026-07-29T19:46:40.555Z [huggingfaceserver] WARNING 07-29 19:46:40 [symm_mem.py:67] SymmMemCommunicator: Device capability 7.5 not supported, communicator is not available.
2026-07-29T19:46:40.555Z [huggingfaceserver] WARNING 07-29 19:46:40 [symm_mem.py:67] SymmMemCommunicator: Device capability 7.5 not supported, communicator is not available.
2026-07-29T19:46:40.586Z [huggingfaceserver] INFO 07-29 19:46:40 [parallel_state.py:1423] rank 1 in world size 2 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 1, EP rank N/A
2026-07-29T19:46:40.586Z [huggingfaceserver] INFO 07-29 19:46:40 [parallel_state.py:1423] rank 0 in world size 2 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank N/A
2026-07-29T19:46:41.731Z [huggingfaceserver] (Worker_TP0 pid=407) INFO 07-29 19:46:41 [gpu_model_runner.py:4033] Starting to load model /mnt/models...
2026-07-29T19:46:42.108Z [huggingfaceserver] (Worker_TP1 pid=408) ERROR 07-29 19:46:42 [fa_utils.py:86] Cannot use FA version 2 is not supported due to FA2 is only supported on devices with compute capability >= 8
2026-07-29T19:46:42.109Z [huggingfaceserver] (Worker_TP0 pid=407) ERROR 07-29 19:46:42 [fa_utils.py:86] Cannot use FA version 2 is not supported due to FA2 is only supported on devices with compute capability >= 8
2026-07-29T19:46:45.877Z [huggingfaceserver] (Worker_TP1 pid=408) /usr/local/lib/python3.12/dist-packages/tvm_ffi/_optional_torch_c_dlpack.py:174: UserWarning: Failed to JIT torch c dlpack extension, EnvTensorAllocator will not be enabled.
2026-07-29T19:46:45.877Z [huggingfaceserver] (Worker_TP1 pid=408) We recommend installing via `pip install torch-c-dlpack-ext`
2026-07-29T19:46:45.877Z [huggingfaceserver] (Worker_TP1 pid=408)   warnings.warn(
2026-07-29T19:46:45.973Z [huggingfaceserver] (Worker_TP0 pid=407) /usr/local/lib/python3.12/dist-packages/tvm_ffi/_optional_torch_c_dlpack.py:174: UserWarning: Failed to JIT torch c dlpack extension, EnvTensorAllocator will not be enabled.
2026-07-29T19:46:45.973Z [huggingfaceserver] (Worker_TP0 pid=407) We recommend installing via `pip install torch-c-dlpack-ext`
2026-07-29T19:46:45.973Z [huggingfaceserver] (Worker_TP0 pid=407)   warnings.warn(
2026-07-29T19:46:47.197Z [huggingfaceserver] (Worker_TP0 pid=407) INFO 07-29 19:46:47 [cuda.py:364] Using FLASHINFER attention backend out of potential backends: ('FLASHINFER', 'TRITON_ATTN', 'FLEX_ATTENTION')
Loading safetensors checkpoint shards:   0% Completed | 0/2 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  50% Completed | 1/2 [00:02<00:02,  2.31s/it]
Loading safetensors checkpoint shards: 100% Completed | 2/2 [00:06<00:00,  3.52s/it]
Loading safetensors checkpoint shards: 100% Completed | 2/2 [00:06<00:00,  3.34s/it]
2026-07-29T19:46:54.116Z [huggingfaceserver] (Worker_TP0 pid=407) 
2026-07-29T19:46:54.168Z [huggingfaceserver] (Worker_TP0 pid=407) INFO 07-29 19:46:54 [default_loader.py:291] Loading weights took 6.72 seconds
2026-07-29T19:46:54.791Z [huggingfaceserver] (Worker_TP0 pid=407) INFO 07-29 19:46:54 [gpu_model_runner.py:4130] Model loading took 2.93 GiB memory and 12.167418 seconds
2026-07-29T19:47:02.719Z [huggingfaceserver] (Worker_TP0 pid=407) INFO 07-29 19:47:02 [backends.py:812] Using cache directory: /var/lib/pebble/default/.cache/vllm/torch_compile_cache/27cf2d62f5/rank_0_0/backbone for vLLM's torch.compile
2026-07-29T19:47:02.720Z [huggingfaceserver] (Worker_TP0 pid=407) INFO 07-29 19:47:02 [backends.py:872] Dynamo bytecode transform time: 7.62 s
2026-07-29T19:47:12.004Z [huggingfaceserver] (Worker_TP0 pid=407) INFO 07-29 19:47:12 [backends.py:302] Cache the graph of compile range (1, 2048) for later use
2026-07-29T19:47:12.027Z [huggingfaceserver] (Worker_TP1 pid=408) INFO 07-29 19:47:12 [backends.py:302] Cache the graph of compile range (1, 2048) for later use
2026-07-29T19:47:12.767Z [huggingfaceserver] (Worker_TP0 pid=407) [rank0]:W0729 19:47:12.767000 407 usr/local/lib/python3.12/dist-packages/torch/_inductor/utils.py:1613] Not enough SMs to use max_autotune_gemm mode
2026-07-29T19:47:12.786Z [huggingfaceserver] (Worker_TP1 pid=408) [rank1]:W0729 19:47:12.786000 408 usr/local/lib/python3.12/dist-packages/torch/_inductor/utils.py:1613] Not enough SMs to use max_autotune_gemm mode
2026-07-29T19:47:18.632Z [huggingfaceserver] (Worker_TP0 pid=407) INFO 07-29 19:47:18 [backends.py:319] Compiling a graph for compile range (1, 2048) takes 11.67 s
2026-07-29T19:47:18.633Z [huggingfaceserver] (Worker_TP0 pid=407) INFO 07-29 19:47:18 [monitor.py:34] torch.compile takes 19.29 s in total
2026-07-29T19:47:20.210Z [huggingfaceserver] (Worker_TP0 pid=407) INFO 07-29 19:47:20 [gpu_worker.py:356] Available KV cache memory: 8.94 GiB
2026-07-29T19:47:20.213Z [huggingfaceserver] (EngineCore_DP0 pid=257) INFO 07-29 19:47:20 [kv_cache_utils.py:1307] GPU KV cache size: 520,768 tokens
2026-07-29T19:47:20.213Z [huggingfaceserver] (EngineCore_DP0 pid=257) INFO 07-29 19:47:20 [kv_cache_utils.py:1312] Maximum concurrency for 32,768 tokens per request: 15.89x
2026-07-29T19:47:20.227Z [huggingfaceserver] (Worker_TP1 pid=408) INFO 07-29 19:47:20 [kernel_warmup.py:64] Warming up FlashInfer attention.
2026-07-29T19:47:20.228Z [huggingfaceserver] (Worker_TP0 pid=407) INFO 07-29 19:47:20 [kernel_warmup.py:64] Warming up FlashInfer attention.
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):   0%|          | 0/19 [00:00<?, ?it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):   5%|▌         | 1/19 [00:00<00:02,  6.69it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  11%|█         | 2/19 [00:00<00:02,  6.89it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  16%|█▌        | 3/19 [00:00<00:02,  7.01it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  21%|██        | 4/19 [00:00<00:02,  7.06it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  26%|██▋       | 5/19 [00:00<00:02,  6.92it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  32%|███▏      | 6/19 [00:00<00:01,  7.07it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  37%|███▋      | 7/19 [00:00<00:01,  7.17it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  42%|████▏     | 8/19 [00:01<00:01,  7.24it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  47%|████▋     | 9/19 [00:01<00:01,  7.45it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  53%|█████▎    | 10/19 [00:01<00:01,  7.82it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  58%|█████▊    | 11/19 [00:01<00:00,  8.17it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  63%|██████▎   | 12/19 [00:01<00:00,  8.42it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  68%|██████▊   | 13/19 [00:01<00:00,  8.68it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  74%|███████▎  | 14/19 [00:01<00:00,  8.88it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  79%|███████▉  | 15/19 [00:01<00:00,  9.13it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  84%|████████▍ | 16/19 [00:02<00:00,  9.37it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE):  95%|█████████▍| 18/19 [00:02<00:00,  9.80it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE): 100%|██████████| 19/19 [00:02<00:00,  9.48it/s]
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE): 100%|██████████| 19/19 [00:02<00:00,  8.22it/s]
Capturing CUDA graphs (decode, FULL):   0%|          | 0/11 [00:00<?, ?it/s]
Capturing CUDA graphs (decode, FULL):   9%|▉         | 1/11 [00:00<00:01,  8.81it/s]
Capturing CUDA graphs (decode, FULL):  18%|█▊        | 2/11 [00:00<00:01,  8.86it/s]
Capturing CUDA graphs (decode, FULL):  27%|██▋       | 3/11 [00:00<00:00,  9.02it/s]
Capturing CUDA graphs (decode, FULL):  36%|███▋      | 4/11 [00:00<00:00,  9.10it/s]
Capturing CUDA graphs (decode, FULL):  45%|████▌     | 5/11 [00:00<00:00,  9.20it/s]
Capturing CUDA graphs (decode, FULL):  55%|█████▍    | 6/11 [00:00<00:00,  9.30it/s]
2026-07-29T19:47:23.799Z [huggingfaceserver] (Worker_TP1 pid=408) INFO 07-29 19:47:24 [custom_all_reduce.py:216] Registering 2190 cuda graph addresses
Capturing CUDA graphs (decode, FULL):  73%|███████▎  | 8/11 [00:00<00:00,  9.73it/s]
Capturing CUDA graphs (decode, FULL):  91%|█████████ | 10/11 [00:01<00:00, 10.10it/s]
Capturing CUDA graphs (decode, FULL): 100%|██████████| 11/11 [00:01<00:00,  9.74it/s]
2026-07-29T19:47:24.937Z [huggingfaceserver] (Worker_TP0 pid=407) INFO 07-29 19:47:24 [custom_all_reduce.py:216] Registering 2190 cuda graph addresses
2026-07-29T19:47:25.550Z [huggingfaceserver] (Worker_TP0 pid=407) INFO 07-29 19:47:25 [gpu_model_runner.py:5063] Graph capturing finished in 5 secs, took 0.30 GiB
2026-07-29T19:47:25.580Z [huggingfaceserver] (EngineCore_DP0 pid=257) INFO 07-29 19:47:25 [core.py:272] init engine (profile, create kv cache, warmup model) took 30.78 seconds
2026-07-29T19:47:29.798Z [huggingfaceserver] (EngineCore_DP0 pid=257) INFO 07-29 19:47:29 [vllm.py:624] Asynchronous scheduling is enabled.
2026-07-29T19:47:30.038Z [huggingfaceserver] [2026-07-29 19:47:30] INFO server.py:120: OpenAI endpoints registered
2026-07-29T19:47:30.038Z [huggingfaceserver] [2026-07-29 19:47:30] INFO server.py:130: Time series endpoints not registered
2026-07-29T19:47:30.038Z [huggingfaceserver] [2026-07-29 19:47:30] INFO server.py:181: Starting uvicorn with 1 workers
2026-07-29T19:47:30.095Z [huggingfaceserver] [2026-07-29 19:47:30] INFO server.py:83: Started server process [38]
2026-07-29T19:47:30.095Z [huggingfaceserver] [2026-07-29 19:47:30] INFO on.py:48: Waiting for application startup.
2026-07-29T19:47:30.097Z [huggingfaceserver] [2026-07-29 19:47:30] INFO server.py:70: Starting gRPC server with 4 workers
2026-07-29T19:47:30.098Z [huggingfaceserver] [2026-07-29 19:47:30] INFO server.py:71: Starting gRPC server on [::]:8081
2026-07-29T19:47:30.099Z [huggingfaceserver] WARNING 07-29 19:47:30 [model.py:1371] Default vLLM sampling parameters have been overridden by the model's `generation_config.json`: `{'repetition_penalty': 1.05, 'temperature': 0.7, 'top_k': 20, 'top_p': 0.8}`. If this is not intended, please relaunch vLLM instance with `--generation-config vllm`.
2026-07-29T19:47:30.099Z [huggingfaceserver] [2026-07-29 19:47:30] INFO utils.py:105: V1 AsyncLLM build complete
2026-07-29T19:47:30.099Z [huggingfaceserver] [2026-07-29 19:47:30] INFO on.py:62: Application startup complete.
2026-07-29T19:47:30.100Z [huggingfaceserver] [2026-07-29 19:47:30] INFO server.py:215: Uvicorn running on http://0.0.0.0:8080 (Press CTRL+C to quit)
```

</details>

And the `InferenceService` is ready and healthy:

<details>

```
ubuntu@beldam:~$ kubectl get isvc
NAME               URL                                                   READY   PREV   LATEST   PREVROLLEDOUTREVISION   LATESTREADYREVISION                AGE
qwen25-3b-native   http://qwen25-3b-native.default.10.64.140.43.nip.io   True           100                              qwen25-3b-native-predictor-00001   7m29s
ubuntu@beldam:~$ kubectl get pods
NAME                                                           READY   STATUS      RESTARTS   AGE
gpu-accessibility-test                                         0/1     Completed   0          4h13m
qwen25-3b-native-predictor-00001-deployment-64ccdfd9d5-x9xsw   2/2     Running     0          7m32s
```

</details>