### PR TITLE
ci: Add workflow to automatically rebuild rocks on schedule

### DIFF
--- a/.github/automatic_backport_tracks.yaml
+++ b/.github/automatic_backport_tracks.yaml
@@ -1,0 +1,3 @@
+automatic_backport_tracks:
+  - track/0.15
+  - track/0.17

--- a/.github/workflows/scheduled_rebuild_rocks.yaml
+++ b/.github/workflows/scheduled_rebuild_rocks.yaml
@@ -1,0 +1,15 @@
+name: Scheduled rebuild rocks for all refs
+
+on:
+  schedule:
+    - cron: '0 3 1 * *'   # 1st of each month, 03:00 UTC
+  workflow_dispatch:
+
+jobs:
+
+  scheduled-rebuild-rocks:
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/get-all-rock-refs-and-build-scan-test-publish.yaml@main
+    permissions:
+      contents: read
+      issues: write
+    secrets: inherit


### PR DESCRIPTION
## Summary
This PR:
- Adds a workflow to automatically rebuild and publish all rocks on schedule
- Adds `automatic_backport_tracks.yaml` to rebuild for `track/0.15` and `track/0.17`

## Notes
- With this PR, we have created a new `track/0.17` branch to align with the tracks in the `kserve-operators` repository.
- I slightly modified the scheduled time to run from 04:00 UTC to 03:00 to avoid congestion where the CI in multiple repositories would run at the exact same time


Closes #266